### PR TITLE
Add Airbrake dependency with the minimal configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,9 @@ gem 'sdoc', '~> 0.4.0',        group: :doc
 # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
 gem 'spring',      group: :development
 
+# Send all exceptions through to Airbrake.
+gem 'airbrake', '4.0.0'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,9 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    airbrake (4.0.0)
+      builder
+      multi_json
     arel (5.0.1.20140414130214)
     builder (3.2.2)
     erubis (2.7.0)
@@ -111,6 +114,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake (= 4.0.0)
   jbuilder (~> 2.0)
   logstasher (= 0.6.0)
   rails (= 4.1.5)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,1 @@
+# This file is overwritten on deploy


### PR DESCRIPTION
This is so that we can get the application to post exceptions through
to Errbit.
