### PR TITLE
Set the assets prefix and precompilation file

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,16 +15,7 @@ Bundler.require(*Rails.groups)
 
 module InfoFrontend
   class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
-
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    config.assets.prefix = "info-frontend"
+    config.assets.precompile += %w(application.css)
   end
 end


### PR DESCRIPTION
We'll need to the assets prefix to go through our asset host (read:
CDN) and the precompilation listing so that the asset pipeline knows
what the compile.
