### PR TITLE
Fixes to assets pipeline config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,6 @@ Bundler.require(*Rails.groups)
 
 module InfoFrontend
   class Application < Rails::Application
-    config.assets.prefix = "info-frontend"
-    config.assets.precompile += %w(application.css)
+    config.assets.prefix = "/info-frontend"
   end
 end


### PR DESCRIPTION
- `application.css` doesn't need to be added to precompile list as it's [there by default](http://guides.rubyonrails.org/asset_pipeline.html#precompiling-assets)
- add leading slash so that assets work in dev
