### PR TITLE
Hide metrics for multi-part formats (eg guides)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,6 +32,10 @@
     @extend %contain-floats;
     clear: both;
     padding-bottom: $gutter-two-thirds;
+
+    .no-metrics {
+      @include bold-27;
+    }
   }
   .lead-metric {
     @include media(tablet){

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -9,7 +9,7 @@ class InfoController < ApplicationController
     if metadata
       @artefact = metadata.fetch("artefact")
       @needs = metadata.fetch("needs")
-      @lead_metrics = lead_metrics_from(metadata.fetch("performance").fetch("data"))
+      @lead_metrics = lead_metrics_from(@artefact, metadata.fetch("performance").fetch("data"))
     else
       response.headers[Slimmer::Headers::SKIP_HEADER] = "1"
       head 404
@@ -17,8 +17,12 @@ class InfoController < ApplicationController
   end
 
 private
-  def lead_metrics_from(performance_data)
-    uniques = performance_data.map {|l| l["uniquePageViews"] }
-    PerformanceData::LeadMetrics.new(unique_pageviews: uniques)
+  def lead_metrics_from(artefact, performance_data)
+    if artefact.fetch("details")["parts"]
+      return nil # can't present metrics for multi-part content yet
+    else
+      uniques = performance_data.map {|l| l["uniquePageViews"] }
+      PerformanceData::LeadMetrics.new(unique_pageviews: uniques)
+    end
   end
 end

--- a/app/views/info/_lead_metrics.html.erb
+++ b/app/views/info/_lead_metrics.html.erb
@@ -1,7 +1,13 @@
 <div class="lead-metrics">
-  <div class="lead-metric page-views">
-    <p class="count">
-      <%= formatted_traffic(lead_metrics.unique_pageviews_average) %> <span class="title">unique pageviews per day</span>
-    </p>
-  </div>
+  <% if lead_metrics %>
+    <div class="lead-metric page-views">
+      <p class="count">
+        <%= formatted_traffic(lead_metrics.unique_pageviews_average) %> <span class="title">unique pageviews per day</span>
+      </p>
+    </div>
+  <% else %>
+    <div class="no-metrics">
+      <p>Accurate metrics for multi-part formats aren't available yet.</p>
+    </div>
+  <% end %>
 </div>

--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -35,6 +35,14 @@ feature "Info page" do
     expect(page).to have_text("25k unique pageviews per day")
   end
 
+  scenario "Seeing metrics for multi-part formats" do
+    stub_metadata_api_has_slug('apply-uk-visa', metadata_api_response_for_multipart_artefact)
+
+    visit "/info/apply-uk-visa"
+
+    expect(page).to have_text("Accurate metrics for multi-part formats aren't available yet.")
+  end
+
   scenario "Seeing where there aren't any recorded user needs" do
     stub_metadata_api_has_slug('some-slug', metadata_api_response_with_no_needs)
 

--- a/spec/support/metadata_api_helpers.rb
+++ b/spec/support/metadata_api_helpers.rb
@@ -92,6 +92,16 @@ module MetadataAPIHelpers
       response["performance"]["data"] = []
     end
   end
+
+  def metadata_api_response_for_multipart_artefact
+    metadata_api_response_for_apply_uk_visa.tap do |response|
+      response["artefact"]["details"]["parts"] = [
+        { "web_url" => response["artefact"]["web_url"] + "/part-1" },
+        { "web_url" => response["artefact"]["web_url"] + "/part-2" },
+        { "web_url" => response["artefact"]["web_url"] + "/part-3" },
+      ]
+    end
+  end
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
Until we can aggregate the traffic etc from all sections, we shouldn't show metrics for multi-part guides at all, because they're currently wrong.
