### PR TITLE
Show on page searches on info page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,10 +41,6 @@
     @include media(tablet){
       width: $one-third;
       float: left;
-
-      &.page-views {
-        width: $one-third;
-      }
     }
   }
 

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -22,7 +22,11 @@ private
       return nil # can't present metrics for multi-part content yet
     else
       uniques = (performance_data["page_views"] || []).map {|l| l["value"] }
-      PerformanceData::LeadMetrics.new(unique_pageviews: uniques)
+      searches = (performance_data["searches"] || []).map {|l| l["value"] }
+      PerformanceData::LeadMetrics.new(
+        unique_pageviews: uniques,
+        exits_via_search: searches,
+      )
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  def formatted_traffic(size)
+  def human_readable_number(size)
     if size > 0 && size < 1
       "< 1"
     else

--- a/app/views/info/_lead_metrics.html.erb
+++ b/app/views/info/_lead_metrics.html.erb
@@ -1,13 +1,22 @@
-<div class="lead-metrics">
-  <% if lead_metrics %>
-    <div class="lead-metric page-views">
+<% if lead_metrics %>
+  <div class="lead-metrics">
+    <div class="lead-metric">
       <p class="count">
-        <%= formatted_traffic(lead_metrics.unique_pageviews_average) %> <span class="title">unique pageviews per day</span>
+        <%= human_readable_number(lead_metrics.unique_pageviews_average) %> <span class="title">unique pageviews per day</span>
       </p>
     </div>
-  <% else %>
+  </div>
+  <div class="lead-metrics">
+    <div class="lead-metric">
+      <p class="count">
+        <%= human_readable_number(lead_metrics.exits_via_search_average) %> <span class="title">users per day leave via the site search</span>
+      </p>
+    </div>
+  </div>
+<% else %>
+  <div class="lead-metrics">
     <div class="no-metrics">
       <p>Accurate metrics for multi-part formats aren't available yet.</p>
     </div>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/lib/performance_data/lead_metrics.rb
+++ b/lib/performance_data/lead_metrics.rb
@@ -5,8 +5,16 @@ module PerformanceData
     end
 
     def unique_pageviews_average
-      traffic = @data[:unique_pageviews]
-      traffic.empty? ? 0 : traffic.inject(0, :+) / traffic.size.to_f
+      average(@data[:unique_pageviews])
+    end
+
+    def exits_via_search_average
+      average(@data[:exits_via_search])
+    end
+
+  private
+    def average(list)
+      list.empty? ? 0 : list.inject(0, :+) / list.size.to_f
     end
   end
 end

--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -43,6 +43,14 @@ feature "Info page" do
     expect(page).to have_text("Accurate metrics for multi-part formats aren't available yet.")
   end
 
+  scenario "Seeing how many users are leaving via the site search" do
+    stub_metadata_api_has_slug('apply-uk-visa', metadata_api_response_for_apply_uk_visa)
+
+    visit "/info/apply-uk-visa"
+
+    expect(page).to have_text("20 users per day leave via the site search")
+  end
+
   scenario "Seeing where there aren't any recorded user needs" do
     stub_metadata_api_has_slug('some-slug', metadata_api_response_with_no_needs)
 
@@ -57,6 +65,7 @@ feature "Info page" do
     visit "/info/some-slug"
 
     expect(page).to have_text("0 unique pageviews per day")
+    expect(page).to have_text("0 users per day leave via the site search")
   end
 
   scenario "When no information is available for a given slug" do

--- a/spec/models/performance_data/lead_metrics_spec.rb
+++ b/spec/models/performance_data/lead_metrics_spec.rb
@@ -21,5 +21,12 @@ module PerformanceData
         its(:unique_pageviews_average) { should eq(0.5) }
       end
     end
+
+    context "users leaving through search" do
+      context "some on-page searches" do
+        let(:data) { { exits_via_search: [3, 2, 1] } }
+        its(:exits_via_search_average) { should eq(2) }
+      end
+    end
   end
 end

--- a/spec/support/metadata_api_helpers.rb
+++ b/spec/support/metadata_api_helpers.rb
@@ -47,6 +47,13 @@ module MetadataAPIHelpers
           "timestamp"=>"2014-07-01T00:00:00Z"},
          {"value"=>26000,
           "timestamp"=>"2014-07-02T00:00:00Z"}],
+       "searches"=>
+        [{"value"=>20,
+          "timestamp"=>"2014-07-03T00:00:00Z"},
+         {"value"=>15,
+          "timestamp"=>"2014-07-01T00:00:00Z"},
+         {"value"=>25,
+          "timestamp"=>"2014-07-02T00:00:00Z"}],
         },
      "_response_info"=>{"status"=>"ok"}}
   end

--- a/spec/views/info/_lead_metrics.html.erb_spec.rb
+++ b/spec/views/info/_lead_metrics.html.erb_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 require "ostruct"
 
 RSpec.describe "info/lead_metrics" do
-  let(:locals) { { lead_metrics: OpenStruct.new(data) } }
+  let(:defaults) { { unique_pageviews_average: 0, exits_via_search_average: 0 } }
+  let(:locals) { { lead_metrics: OpenStruct.new(defaults.merge(data)) } }
 
   context "when there's very little traffic" do
     let(:data) { { unique_pageviews_average: 0.5 } }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/23801/4333695/022f8436-3fe4-11e4-8971-dd70821c509a.png)

I'm not 100% sure about the microcopy on the search metric is really clear.
