### PR TITLE
Display search terms on info page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -46,15 +46,7 @@
     .no-metrics {
       @include bold-27;
     }
-  }
-  .lead-metric {
-    @include media(tablet){
-      width: $one-third;
-      float: left;
-    }
-  }
 
-  .lead-metric {
     .count {
       @include bold-80;
     }
@@ -63,6 +55,46 @@
       display: block;
       margin-top: -10px;
       margin-bottom: $gutter;
+    }
+  }
+
+  .lead-metric {
+    @include media(tablet){
+      width: $one-third;
+      float: left;
+    }
+  }
+
+  .wide-lead-metric {
+    @include media(tablet){
+      width: $two-thirds;
+      float: left;
+    }
+  }
+
+  .search-terms {
+    .search-terms-title {
+      @include bold-24;
+      margin-bottom: $gutter-half;
+    }
+
+    .search-terms-list {
+      @include core-14;
+      @include media(tablet){
+        float: left;
+      }
+      ul {
+        list-style-type: none;
+        max-height: 2.5em;
+        -webkit-column-count: 3; /* Chrome, Safari, Opera */
+        -moz-column-count: 3; /* Firefox */
+        column-count: 3;
+      }
+    }
+
+    @include media(tablet){
+      width: $half;
+      float: left;
     }
   }
 

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -23,9 +23,11 @@ private
     else
       uniques = (performance_data["page_views"] || []).map {|l| l["value"] }
       searches = (performance_data["searches"] || []).map {|l| l["value"] }
+      search_terms = (performance_data["search_terms"] || []).map {|term| { keyword: term["Keyword"], total: term["TotalSearches"] } }
       PerformanceData::LeadMetrics.new(
         unique_pageviews: uniques,
         exits_via_search: searches,
+        search_terms: search_terms,
       )
     end
   end

--- a/app/views/info/_lead_metrics.html.erb
+++ b/app/views/info/_lead_metrics.html.erb
@@ -5,12 +5,30 @@
         <%= human_readable_number(lead_metrics.unique_pageviews_average) %> <span class="title">unique pageviews per day</span>
       </p>
     </div>
+    <div class="wide-lead-metric">
+      <p class="count">
+        <%= human_readable_number(lead_metrics.exits_via_search_average) %> <span class="title">users per day leave via the site search</span>
+      </p>
+    </div>
+
   </div>
   <div class="lead-metrics">
     <div class="lead-metric">
       <p class="count">
-        <%= human_readable_number(lead_metrics.exits_via_search_average) %> <span class="title">users per day leave via the site search</span>
+        &nbsp;
+        <!-- problem reports will go here -->
       </p>
+    </div>
+    <div class="wide-lead-metric search-terms">
+      <h2 class="search-terms-title">Users searched for these terms</h2>
+
+      <div class="search-terms-list">
+        <ul>
+          <% lead_metrics.top_10_search_terms.each do |search_term| %>
+            <li><%= search_term[:keyword] %> (<%= search_term[:total] %>)</li>
+          <% end %>
+        </ul>
+      </div>
     </div>
   </div>
 <% else %>

--- a/lib/performance_data/lead_metrics.rb
+++ b/lib/performance_data/lead_metrics.rb
@@ -12,6 +12,10 @@ module PerformanceData
       average(@data[:exits_via_search])
     end
 
+    def top_10_search_terms
+      @data[:search_terms].sort_by {|term| -1 * term[:total] }.take(10)
+    end
+
   private
     def average(list)
       list.empty? ? 0 : list.inject(0, :+) / list.size.to_f

--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -51,6 +51,15 @@ feature "Info page" do
     expect(page).to have_text("20 users per day leave via the site search")
   end
 
+  scenario "Seeing what terms users are searching for" do
+    stub_metadata_api_has_slug('apply-uk-visa', metadata_api_response_for_apply_uk_visa)
+
+    visit "/info/apply-uk-visa"
+
+    expect(page).to have_text("login (180)")
+    expect(page).to have_text("spouse visa (100)")
+  end
+
   scenario "Seeing where there aren't any recorded user needs" do
     stub_metadata_api_has_slug('some-slug', metadata_api_response_with_no_needs)
 

--- a/spec/models/performance_data/lead_metrics_spec.rb
+++ b/spec/models/performance_data/lead_metrics_spec.rb
@@ -28,5 +28,19 @@ module PerformanceData
         its(:exits_via_search_average) { should eq(2) }
       end
     end
+
+    context "on-page search terms used by users" do
+      context "10 search terms availables" do
+        let(:search_terms) { 1.upto(11).map {|n| { keyword: "some-term-#{n}", total: n } } }
+        let(:data) { { search_terms: search_terms } }
+
+        it "shows the most popular 10 search terms" do
+          2.upto(11).each do |n|
+            expect(subject.top_10_search_terms).to include(keyword: "some-term-#{n}", total: n)
+          end
+          expect(subject.top_10_search_terms).not_to include(keyword: "some-term-1", total: 1)
+        end
+      end
+    end
   end
 end

--- a/spec/support/metadata_api_helpers.rb
+++ b/spec/support/metadata_api_helpers.rb
@@ -54,7 +54,12 @@ module MetadataAPIHelpers
           "timestamp"=>"2014-07-01T00:00:00Z"},
          {"value"=>25,
           "timestamp"=>"2014-07-02T00:00:00Z"}],
-        },
+        "search_terms"=>
+         [{"TotalSearches"=>180,
+           "Keyword"=>"login"},
+          {"TotalSearches"=>100,
+           "Keyword"=>"spouse visa"}],
+         },
      "_response_info"=>{"status"=>"ok"}}
   end
 

--- a/spec/views/info/_lead_metrics.html.erb_spec.rb
+++ b/spec/views/info/_lead_metrics.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "ostruct"
 
 RSpec.describe "info/lead_metrics" do
-  let(:defaults) { { unique_pageviews_average: 0, exits_via_search_average: 0 } }
+  let(:defaults) { { unique_pageviews_average: 0, exits_via_search_average: 0, top_10_search_terms: [] } }
   let(:locals) { { lead_metrics: OpenStruct.new(defaults.merge(data)) } }
 
   context "when there's very little traffic" do
@@ -22,6 +22,17 @@ RSpec.describe "info/lead_metrics" do
       render partial: "info/lead_metrics", locals: locals
 
       expect(rendered).to have_text("12.3k unique pageviews per day")
+    end
+  end
+
+  context "when users have searched on the page" do
+    let(:data) { { top_10_search_terms: [ { total: 4, keyword: "abc" }, { total: 5, keyword: "xyz" } ] } }
+
+    it "displays search terms" do
+      render partial: "info/lead_metrics", locals: locals
+
+      expect(rendered).to have_text("abc (4)")
+      expect(rendered).to have_text("xyz (5)")
     end
   end
 end


### PR DESCRIPTION
This metric allows publishers to see what's missing on the page, or what
topics users aren't getting when they follow the link to that page.

![image](https://cloud.githubusercontent.com/assets/23801/4387044/d7b83e08-43d7-11e4-9df5-0e1cd2d5620e.png)
