### PR TITLE
[DISCUSS] Alternative wording for on-page searches microcopy

### DIFF
--- a/app/views/info/_lead_metrics.html.erb
+++ b/app/views/info/_lead_metrics.html.erb
@@ -7,7 +7,7 @@
     </div>
     <div class="wide-lead-metric">
       <p class="count">
-        <%= human_readable_number(lead_metrics.exits_via_search_average) %> <span class="title">users per day leave via the site search</span>
+        <%= human_readable_number(lead_metrics.exits_via_search_average) %> <span class="title">searches from the page</span>
       </p>
     </div>
 

--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -48,7 +48,7 @@ feature "Info page" do
 
     visit "/info/apply-uk-visa"
 
-    expect(page).to have_text("20 users per day leave via the site search")
+    expect(page).to have_text("20 searches from the page")
   end
 
   scenario "Seeing what terms users are searching for" do
@@ -74,7 +74,7 @@ feature "Info page" do
     visit "/info/some-slug"
 
     expect(page).to have_text("0 unique pageviews per day")
-    expect(page).to have_text("0 users per day leave via the site search")
+    expect(page).to have_text("0 searches from the page")
   end
 
   scenario "When no information is available for a given slug" do


### PR DESCRIPTION
This is language that's been used in the past by the GOV.UK analytics team
and may be more familiar to content designers (suggested by John Byrne).
