### PR TITLE
Hide the 'search terms' label if none present

### DIFF
--- a/app/views/info/_lead_metrics.html.erb
+++ b/app/views/info/_lead_metrics.html.erb
@@ -12,25 +12,29 @@
     </div>
 
   </div>
-  <div class="lead-metrics">
-    <div class="lead-metric">
-      <p class="count">
-        &nbsp;
-        <!-- problem reports will go here -->
-      </p>
-    </div>
-    <div class="wide-lead-metric search-terms">
-      <h2 class="search-terms-title">Users searched for these terms</h2>
-
-      <div class="search-terms-list">
-        <ul>
-          <% lead_metrics.top_10_search_terms.each do |search_term| %>
-            <li><%= search_term[:keyword] %> (<%= search_term[:total] %>)</li>
-          <% end %>
-        </ul>
+  <% if lead_metrics.top_10_search_terms.present? %>
+    <div class="lead-metrics">
+      <div class="lead-metric">
+        <p class="count">
+          &nbsp;
+          <!-- problem reports will go here -->
+        </p>
       </div>
+      <% if lead_metrics.top_10_search_terms.present? %>
+        <div class="wide-lead-metric search-terms">
+          <h2 class="search-terms-title">Users searched for these terms</h2>
+
+          <div class="search-terms-list">
+            <ul>
+              <% lead_metrics.top_10_search_terms.each do |search_term| %>
+                <li><%= search_term[:keyword] %> (<%= search_term[:total] %>)</li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      <% end %>
     </div>
-  </div>
+  <% end %>
 <% else %>
   <div class="lead-metrics">
     <div class="no-metrics">


### PR DESCRIPTION
There are two guards because the outer one will also need to check
for the presence of anonymous feedback.
