### PR TITLE
Enable hiding and showing user needs by using a config initialiser

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -10,6 +10,7 @@ class InfoController < ApplicationController
       @artefact = metadata.fetch("artefact")
       @needs = metadata.fetch("needs")
       @lead_metrics = lead_metrics_from(@artefact, metadata.fetch("performance"))
+      @show_needs = InfoFrontend::FeatureFlags.show_needs
     else
       response.headers[Slimmer::Headers::SKIP_HEADER] = "1"
       head 404

--- a/app/views/info/_artefact.html.erb
+++ b/app/views/info/_artefact.html.erb
@@ -1,6 +1,10 @@
 <div class="floated-children">
   <div class="need-heading">
+  <%- if show_needs %>
     <p>User needs and metrics</p>
+  <%- else %>
+    <p>Metrics</p>
+  <%- end %>
     <h1><%= artefact["title"] %></h1>
   </div>
 </div>

--- a/app/views/info/show.html.erb
+++ b/app/views/info/show.html.erb
@@ -1,8 +1,9 @@
 <% content_for :title do "Information about “#{@artefact["title"]}”" end %>
 
-<%= render partial: "artefact", locals: { artefact: @artefact } %>
+<%= render partial: "artefact", locals: { artefact: @artefact, show_needs: @show_needs } %>
 <%= render partial: "lead_metrics", locals: { lead_metrics: @lead_metrics } %>
 
+<%- if @show_needs %>
 <div class="floated-children">
   <header class="needs-heading">
     <h1>Why is this page on GOV.UK?</h1>
@@ -17,3 +18,4 @@
     <% end %>
   </div>
 </div>
+<%- end %>

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,0 +1,10 @@
+module InfoFrontend
+  module FeatureFlags
+    class << self
+      attr_accessor :show_needs
+    end
+  end
+end
+
+# Show user needs by default.
+InfoFrontend::FeatureFlags.show_needs = true

--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -84,4 +84,36 @@ feature "Info page" do
 
     expect(page.status_code).to eq(404)
   end
+
+  context "configuring whether or not to show the user need" do
+    after(:each) do
+      InfoFrontend::FeatureFlags.show_needs = true
+    end
+
+    scenario "shows the user need by default" do
+      stub_metadata_api_has_slug('apply-uk-visa', metadata_api_response_for_apply_uk_visa)
+
+      visit "/info/apply-uk-visa"
+
+      expect(page).to have_text("User needs and metrics")
+      expect(page).to have_text("non-EEA national")
+      expect(page).to have_text("apply for a UK visa")
+      expect(page).to have_text("I can come to the UK to visit, study or work")
+    end
+
+    scenario "doesn't show the user need if set to false" do
+      InfoFrontend::FeatureFlags.show_needs = false
+
+      stub_metadata_api_has_slug('apply-uk-visa', metadata_api_response_for_apply_uk_visa)
+
+      visit "/info/apply-uk-visa"
+
+      expect(page).to_not have_text("User needs and metrics")
+      expect(page).to_not have_text("non-EEA national")
+      expect(page).to_not have_text("apply for a UK visa")
+      expect(page).to_not have_text("I can come to the UK to visit, study or work")
+
+      expect(page).to have_text("Metrics")
+    end
+  end
 end


### PR DESCRIPTION
This adds a `InfoFrontend::FeatureFlags` module that we can use to set
different configuration per environment.

Using the feature flag attribute of `show_needs` we can hide and show
user needs by changing the value in this file.
