### PR TITLE
Move location of `FeatureFlags` module and use `mattr_accessor`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,4 +17,8 @@ module InfoFrontend
   class Application < Rails::Application
     config.assets.prefix = "/info-frontend"
   end
+
+  module FeatureFlags
+    mattr_accessor :show_needs
+  end
 end

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,8 +1,0 @@
-module InfoFrontend
-  module FeatureFlags
-    mattr_accessor :show_needs
-  end
-end
-
-# Show user needs by default.
-InfoFrontend::FeatureFlags.show_needs = true

--- a/config/initializers/show_needs.rb
+++ b/config/initializers/show_needs.rb
@@ -1,0 +1,2 @@
+# Show user needs by default. This file might be overriden at deploy.
+InfoFrontend::FeatureFlags.show_needs = true


### PR DESCRIPTION
Instead of using `self` use the idiomatic way of defining attributes on a module with `mattr_accessor`.
