### PR TITLE
Reword to say "searches per day"

### DIFF
--- a/app/views/info/_lead_metrics.html.erb
+++ b/app/views/info/_lead_metrics.html.erb
@@ -7,7 +7,7 @@
     </div>
     <div class="wide-lead-metric">
       <p class="count">
-        <%= human_readable_number(lead_metrics.exits_via_search_average) %> <span class="title">searches per day from the page</span>
+        <%= human_readable_number(lead_metrics.exits_via_search_average) %> <span class="title">searches per day</span>
       </p>
     </div>
 

--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -48,7 +48,7 @@ feature "Info page" do
 
     visit "/info/apply-uk-visa"
 
-    expect(page).to have_text("20 searches per day from the page")
+    expect(page).to have_text("20 searches per day")
   end
 
   scenario "Seeing how problem reports are left" do
@@ -82,7 +82,7 @@ feature "Info page" do
     visit "/info/some-slug"
 
     expect(page).to have_text("0 unique pageviews per day")
-    expect(page).to have_text("0 searches per day from the page")
+    expect(page).to have_text("0 searches per day")
   end
 
   scenario "When no information is available for a given slug" do


### PR DESCRIPTION
The extra "from the page" is unnecessary.
