### PR TITLE
Update `max-height` to fit all ten search terms

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -85,7 +85,7 @@
       }
       ul {
         list-style-type: none;
-        max-height: 2.5em;
+        max-height: 200px;
         -webkit-column-count: 3; /* Chrome, Safari, Opera */
         -moz-column-count: 3; /* Firefox */
         column-count: 3;


### PR DESCRIPTION
The terms were breaking out of their containing box on FF. This sets a
more realistic `max-height` so that they don't break out.
