### PR TITLE
Increase cache expiry time to 12 hours

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
 private
-  def set_expiry(duration = 30.minutes)
+  def set_expiry(duration = 12.hours)
     unless Rails.env.development?
       expires_in(duration, public: true)
     end

--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -24,7 +24,7 @@ feature "Info page" do
     expect(page).to have_text("How to apply")
     expect(page).to have_text("What documents to provide")
 
-    expect(page.response_headers["Cache-Control"]).to eq("max-age=1800, public")
+    expect(page.response_headers["Cache-Control"]).to eq("max-age=43200, public")
   end
 
   scenario "Seeing how many visits are made to a page" do


### PR DESCRIPTION
The underlying data for this page won't update more than every day so
we should set a better cache time to reduce the number of requests we
receive and make to our dependent services.
