### PR TITLE
Enable displaying needs from a whitelist in prod

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -9,8 +9,11 @@ class InfoController < ApplicationController
     if metadata
       @artefact = metadata.fetch("artefact")
       @needs = metadata.fetch("needs")
+      if InfoFrontend::FeatureFlags.needs_to_show == :only_validated
+        @needs.select! { |need| InfoFrontend::FeatureFlags.validated_need_ids.include?(need["id"]) }
+      end
       @lead_metrics = lead_metrics_from(@artefact, metadata.fetch("performance"))
-      @show_needs = InfoFrontend::FeatureFlags.show_needs
+      @show_needs = [:all, :only_validated].include?(InfoFrontend::FeatureFlags.needs_to_show)
     else
       response.headers[Slimmer::Headers::SKIP_HEADER] = "1"
       head 404

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,7 @@ module InfoFrontend
   end
 
   module FeatureFlags
-    mattr_accessor :show_needs
+    mattr_accessor :needs_to_show
+    mattr_accessor :validated_need_ids
   end
 end

--- a/config/initializers/show_needs.rb
+++ b/config/initializers/show_needs.rb
@@ -1,2 +1,2 @@
 # Show user needs by default. This file might be overriden at deploy.
-InfoFrontend::FeatureFlags.show_needs = true
+InfoFrontend::FeatureFlags.needs_to_show = :all

--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -95,7 +95,7 @@ feature "Info page" do
 
   context "configuring whether or not to show the user need" do
     after(:each) do
-      InfoFrontend::FeatureFlags.show_needs = true
+      InfoFrontend::FeatureFlags.needs_to_show = :all
     end
 
     scenario "shows the user need by default" do
@@ -109,8 +109,8 @@ feature "Info page" do
       expect(page).to have_text("I can come to the UK to visit, study or work")
     end
 
-    scenario "doesn't show the user need if set to false" do
-      InfoFrontend::FeatureFlags.show_needs = false
+    scenario "doesn't show the user need if needs are hidden" do
+      InfoFrontend::FeatureFlags.needs_to_show = :none
 
       stub_metadata_api_has_slug('apply-uk-visa', metadata_api_response_for_apply_uk_visa)
 
@@ -122,6 +122,32 @@ feature "Info page" do
       expect(page).to_not have_text("I can come to the UK to visit, study or work")
 
       expect(page).to have_text("Metrics")
+    end
+
+    scenario "doesn't show the user need if it's not validated" do
+      InfoFrontend::FeatureFlags.needs_to_show = :only_validated
+      InfoFrontend::FeatureFlags.validated_need_ids = [ 100999 ]
+
+      stub_metadata_api_has_slug('apply-uk-visa', metadata_api_response_for_apply_uk_visa)
+
+      visit "/info/apply-uk-visa"
+
+      expect(page).to have_text("User needs and metrics")
+      expect(page).to_not have_text("apply for a UK visa")
+    end
+
+    scenario "shows the user need if it's validated" do
+      InfoFrontend::FeatureFlags.needs_to_show = :only_validated
+      InfoFrontend::FeatureFlags.validated_need_ids = [
+        metadata_api_response_for_apply_uk_visa["needs"].first["id"]
+      ]
+
+      stub_metadata_api_has_slug('apply-uk-visa', metadata_api_response_for_apply_uk_visa)
+
+      visit "/info/apply-uk-visa"
+
+      expect(page).to have_text("User needs and metrics")
+      expect(page).to have_text("apply for a UK visa")
     end
   end
 end


### PR DESCRIPTION
The hardcoding of the need IDs is only a very temporary measure while need validation
is being added to Maslow (this feature is in progress).

There is precedent for this approach in alpha projects (eg the data for the Employment Income Manual
being hardcoded within the Manuals frontend application).

https://github.gds/gds/alphagov-deployment/pull/758 needs to be merged first.
