### PR TITLE
Handle invalid slugs

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -1,8 +1,10 @@
 require 'govuk/client/metadata_api'
 require 'performance_data/lead_metrics'
+require 'slimmer/headers'
 
 class InfoController < ApplicationController
   before_filter :set_expiry, only: :show
+  before_filter :validate_slug
 
   def show
     metadata = GOVUK::Client::MetadataAPI.new.info(params[:slug])
@@ -35,6 +37,17 @@ private
         search_terms: search_terms,
         problem_reports: problem_reports,
       )
+    end
+  end
+
+  def validate_slug
+    begin
+      URI.parse("/" + params[:slug])
+    rescue URI::InvalidURIError
+      # skipping slimmer because it doesn't seem to like empty responses
+      response.headers[Slimmer::Headers::SKIP_HEADER] = "1"
+      head :not_found
+      false
     end
   end
 end

--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -93,6 +93,12 @@ feature "Info page" do
     expect(page.status_code).to eq(404)
   end
 
+  scenario "When an invalid slug is provided" do
+    visit '/info/%27%22--%3E%3C'
+
+    expect(page.status_code).to eq(404)
+  end
+
   context "configuring whether or not to show the user need" do
     after(:each) do
       InfoFrontend::FeatureFlags.needs_to_show = :all


### PR DESCRIPTION
For invalid slugs (eg `/info/""<--`) caused by malicious attempts or
a user mistyping the URL, the app now returns 404 instead of 500.
