### PR TITLE
Handle slugs that need encoding

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -5,7 +5,8 @@ class InfoController < ApplicationController
   before_filter :set_expiry, only: :show
 
   def show
-    metadata = GOVUK::Client::MetadataAPI.new.info(params[:slug])
+    slug = URI.encode(params[:slug])
+    metadata = GOVUK::Client::MetadataAPI.new.info(slug)
     if metadata
       @artefact = metadata.fetch("artefact")
       @needs = metadata.fetch("needs")

--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -93,6 +93,14 @@ feature "Info page" do
     expect(page.status_code).to eq(404)
   end
 
+  scenario "when a slug that needs encoding is provided" do
+    stub_metadata_api_has_slug('government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8', metadata_api_response_for_apply_uk_visa)
+
+    visit '/info/government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8'
+
+    expect(page.status_code).to eq(200)
+  end
+
   context "configuring whether or not to show the user need" do
     after(:each) do
       InfoFrontend::FeatureFlags.needs_to_show = :all


### PR DESCRIPTION
Before this change, slugs that needed encoding (eg /info/""<--) raised exceptions. Such
slugs can be requested by malicious attempts or when a user mistypes the URL.