### PR TITLE
Use govuk_components rather than slimmer inserter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Slimmer::SharedTemplates
+
   before_filter :set_slimmer_headers
 
   # Prevent CSRF attacks by raising an exception.
@@ -14,6 +16,5 @@ private
 
   def set_slimmer_headers
     response.headers[Slimmer::Headers::TEMPLATE_HEADER] = "header_footer_only"
-    response.headers[Slimmer::Headers::ALPHA_LABEL] = "before:.info-frontend"
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
   <div id="wrapper">
     <div class="outer-block">
       <div class="inner-block">
+        <%= render 'govuk_component/alpha_label' %>
         <div class="info-frontend">
           <%= yield %>
         </div>


### PR DESCRIPTION
Use the govuk_component alpha label rather than the slimmer inserted
one. This will let us iterate the design in a faster more consistent
way.

This will need static to be deployed before this as the alpha-label isn't on production yet.