### PR TITLE
Remove deprecated Metadata API fields

### DIFF
--- a/spec/support/metadata_api_helpers.rb
+++ b/spec/support/metadata_api_helpers.rb
@@ -36,8 +36,6 @@ module MetadataAPIHelpers
         "other_evidence"=>"",
         "legislation"=>"",
         "applies_to_all_organisations"=>false,
-        "in_scope"=>false,
-        "out_of_scope_reason"=>"",
         "duplicate_of"=>0}],
      "performance"=>
       {"page_views"=>


### PR DESCRIPTION
These fields no longer appear in Need API and have also been
[removed from Metadata API](https://github.com/alphagov/metadata-api/pull/15).