### PR TITLE
Only show validated needs

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -10,16 +10,12 @@ class InfoController < ApplicationController
     metadata = GOVUK::Client::MetadataAPI.new.info(@slug)
     if metadata
       @artefact = metadata.fetch("artefact")
-      @needs = metadata.fetch("needs")
-      if InfoFrontend::FeatureFlags.needs_to_show == :only_validated
-        @needs.select! { |need| InfoFrontend::FeatureFlags.validated_need_ids.include?(need["id"]) }
-      end
+      @needs = metadata.fetch("needs").select {|need| need["status"]["description"] == "valid" }
       part_urls = get_part_urls(@artefact, @slug)
       @is_multipart = is_multipart(part_urls, @artefact.fetch("format"))
       calculated_metrics = metrics_from(@artefact, metadata.fetch("performance"), part_urls, @is_multipart)
       @lead_metrics = calculated_metrics[:lead_metrics]
       @per_page_metrics = calculated_metrics[:per_page_metrics]
-      @show_needs = [:all, :only_validated].include?(InfoFrontend::FeatureFlags.needs_to_show)
     else
       response.headers[Slimmer::Headers::SKIP_HEADER] = "1"
       head 404

--- a/app/views/info/_artefact.html.erb
+++ b/app/views/info/_artefact.html.erb
@@ -1,10 +1,6 @@
 <div class="padding-for-tablets">
   <div class="need-heading">
-  <%- if show_needs %>
-    <p class="type">User needs and metrics</p>
-  <%- else %>
-    <p class="type">Metrics</p>
-  <%- end %>
+  <p class="type">User needs and metrics</p>
   <h1><%= artefact["title"] %></h1>
   <p class="introduction">
     All metrics are recorded over the past 6 weeks.

--- a/app/views/info/_needs.html.erb
+++ b/app/views/info/_needs.html.erb
@@ -1,4 +1,3 @@
-<%- if show_needs %>
 <section id="needs">
   <header class="needs-heading">
     <h1>Why <%- if is_multipart %> are these pages <%- else %> is this page <%- end %> on GOV.UK?</h1>
@@ -8,9 +7,8 @@
     <%= render partial: "need_details", collection: needs, as: 'need', spacer_template: "spacer" %>
     <% else %>
     <div class="role-goal-benefit-panel">
-      <h2 class="no-need">There aren’t any recorded needs for this page.</h2>
+      <h2 class="no-need">There aren’t any validated needs for this page.</h2>
     </div>
     <% end %>
   </div>
 </section>
-<%- end %>

--- a/app/views/info/show.html.erb
+++ b/app/views/info/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title do "Information about “#{@artefact["title"]}”" end %>
 
-<%= render partial: "artefact", locals: { artefact: @artefact, show_needs: @show_needs } %>
+<%= render partial: "artefact", locals: { artefact: @artefact } %>
 <%= render partial: "lead_metrics", locals: { lead_metrics: @lead_metrics, is_multipart: @is_multipart } %>
 <%= render partial: "per_page_metrics", locals: { per_page_metrics: @per_page_metrics } %>
-<%= render partial: "needs", locals: { show_needs: @show_needs, needs: @needs, is_multipart: @is_multipart } %>
+<%= render partial: "needs", locals: { needs: @needs, is_multipart: @is_multipart } %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,9 +17,4 @@ module InfoFrontend
   class Application < Rails::Application
     config.assets.prefix = "/info-frontend"
   end
-
-  module FeatureFlags
-    mattr_accessor :needs_to_show
-    mattr_accessor :validated_need_ids
-  end
 end

--- a/config/initializers/show_needs.rb
+++ b/config/initializers/show_needs.rb
@@ -1,2 +1,0 @@
-# Show user needs by default. This file might be overriden at deploy.
-InfoFrontend::FeatureFlags.needs_to_show = :all

--- a/spec/support/metadata_api_helpers.rb
+++ b/spec/support/metadata_api_helpers.rb
@@ -29,6 +29,9 @@ module MetadataAPIHelpers
          ["Finds out how whether they're eligible",
           "How to apply",
           "What documents to provide"],
+        "status"=>{
+          "description"=>"valid",
+        },
         "yearly_user_contacts"=>0,
         "yearly_site_views"=>0,
         "yearly_need_views"=>0,
@@ -100,6 +103,12 @@ module MetadataAPIHelpers
   def metadata_api_response_with_no_performance_data
     metadata_api_response_for_apply_uk_visa.tap do |response|
       response["performance"] = {}
+    end
+  end
+
+  def metadata_api_response_with_an_invalid_need
+    metadata_api_response_for_apply_uk_visa.tap do |response|
+      response["needs"].first["status"]["description"] = "proposed"
     end
   end
 


### PR DESCRIPTION
This change simplifies the decision of whether to display a need or not.
After this change, the need is show if it's valid, and hidden if it's not.

Before this is released to production, it's necessary to merge [the deployment config change](https://github.gds/gds/alphagov-deployment/pull/863).