### PR TITLE
Link searches to search results

### DIFF
--- a/app/views/info/_lead_metrics.html.erb
+++ b/app/views/info/_lead_metrics.html.erb
@@ -38,7 +38,9 @@
           <div class="search-terms-list">
             <ul>
               <% lead_metrics.top_10_search_terms.each do |search_term| %>
-                <li><%= search_term[:keyword] %> (<%= search_term[:total] %>)</li>
+                <li>
+                  <%= link_to search_term[:keyword], "/search?q=#{search_term[:keyword]}" %> (<%= search_term[:total] %>)
+                </li>
               <% end %>
             </ul>
           </div>


### PR DESCRIPTION
Make it easy to see the type of search results users are seeing when they leave a page using a common search term.

![screen shot 2015-04-13 at 16 49 09](https://cloud.githubusercontent.com/assets/319055/7119366/07dd7bde-e1fd-11e4-8a56-38315f227af4.png)

cc @benilovj @rboulton 