### PR TITLE
Bump slimmer for rendering app meta tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'sass-rails', '4.0.3'
 gem 'uglifier', '2.5.3'
 gem 'spring', group: :development
 gem 'airbrake', '4.0.0'
-gem 'slimmer', '8.1.0'
+gem 'slimmer', '8.2.1'
 gem 'plek', '1.9.0'
 gem 'govuk-client-url_arbiter', '0.0.2'
 gem 'govuk_frontend_toolkit', '1.6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0)
-    slimmer (8.1.0)
+    slimmer (8.2.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -190,7 +190,7 @@ DEPENDENCIES
   rspec-its (= 1.0.1)
   rspec-rails (= 3.1.0)
   sass-rails (= 4.0.3)
-  slimmer (= 8.1.0)
+  slimmer (= 8.2.1)
   spring
   uglifier (= 2.5.3)
   unicorn (= 4.8.3)


### PR DESCRIPTION
So we can track which application renders which page in analytics update
slimmer for a new version which outputs the rendering application.

This contains both https://github.com/alphagov/slimmer/pull/126 and https://github.com/alphagov/slimmer/pull/128