### PR TITLE
Upgrade Slimmer, explicitly set layout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'sass-rails', '4.0.3'
 gem 'uglifier', '2.5.3'
 gem 'spring', group: :development
 gem 'airbrake', '4.0.0'
-gem 'slimmer', '8.2.1'
+gem 'slimmer', '9.0.0'
 gem 'plek', '1.11.0'
 gem 'govuk-client-url_arbiter', '0.0.2'
 gem 'govuk_frontend_toolkit', '1.6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0)
-    slimmer (8.2.1)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -192,7 +192,7 @@ DEPENDENCIES
   rspec-its (= 1.0.1)
   rspec-rails (= 3.1.0)
   sass-rails (= 4.0.3)
-  slimmer (= 8.2.1)
+  slimmer (= 9.0.0)
   spring
   uglifier (= 2.5.3)
   unicorn (= 4.8.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,8 @@
 class ApplicationController < ActionController::Base
+  include Slimmer::Template
   include Slimmer::SharedTemplates
 
-  before_filter :set_slimmer_headers
+  slimmer_template "header_footer_only"
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -12,9 +13,5 @@ private
     unless Rails.env.development?
       expires_in(duration, public: true)
     end
-  end
-
-  def set_slimmer_headers
-    response.headers[Slimmer::Headers::TEMPLATE_HEADER] = "header_footer_only"
   end
 end


### PR DESCRIPTION
This is a no-op change to app behaviour. The same Slimmer layout is used as be
before, but set in a simple, standardised way with slimmer_template, which is
easier to grep for than the other methods.

Slimmer 9.0.0 switched to core_layout [1] as the default layout, which is the
modern/recommend layout. Apps not yet using core_layout should be explicitly
marked as such, so we can easily identify them as needing updating.

I had a quick look at what would be required to use core_layout, and it's
actually very little, I think it would just need some tweaking of the local
grid styles.

Still, it's better to do that in a separate PR, so it can be reviewed/tested
specifically.

[1] alphagov/slimmer#136