### PR TITLE
Use core layout & title component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,10 +6,9 @@
 
 
 .info-frontend {
-  padding-top: $gutter-half;
   margin-bottom: $gutter;
   @include media(tablet){
-    padding-top: $gutter;
+    padding-top: $gutter-half;
     margin-bottom: $gutter * 2;
   }
   @extend %contain-floats;
@@ -190,15 +189,6 @@
 
   .need-heading {
     margin-bottom: $gutter;
-
-    p.type {
-      @include core-24;
-      color: $secondary-text-colour;
-    }
-    h1 {
-      @include bold-48;
-      margin-bottom: $gutter-one-third;
-    }
   }
 
   .role-goal-benefit-panel {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,16 +1,9 @@
-@import "grid_layout";
+@import "measurements";
 @import "typography";
 @import "colours";
 @import "reset";
 @import "shims";
 
-.outer-block {
-  @include outer-block;
-}
-
-.inner-block {
-  @include inner-block;
-}
 
 .info-frontend {
   padding-top: $gutter-half;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,5 @@
 class ApplicationController < ActionController::Base
-  include Slimmer::Template
   include Slimmer::SharedTemplates
-
-  slimmer_template "header_footer_only"
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/views/info/_artefact.html.erb
+++ b/app/views/info/_artefact.html.erb
@@ -1,9 +1,9 @@
-<div class="padding-for-tablets">
-  <div class="need-heading">
-  <p class="type">User needs and metrics</p>
-  <h1><%= artefact["title"] %></h1>
+<div class="need-heading">
+  <%= render partial: 'govuk_component/title', locals: {
+  context: "User needs and metrics",
+  title: artefact["title"]
+  } %>
   <p class="introduction">
     All metrics are recorded over the past 6 weeks.
   </p>
-  </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,14 +8,10 @@
 <body>
   <div id="global-breadcrumb" class="header-context"></div>
   <div id="wrapper">
-    <div class="outer-block">
-      <div class="inner-block">
-        <%= render 'govuk_component/alpha_label' %>
-        <main role="main" class="info-frontend">
-          <%= yield %>
-        </main>
-      </div>
-    </div>
+    <%= render 'govuk_component/alpha_label' %>
+    <main role="main" class="info-frontend">
+      <%= yield %>
+    </main>
   </div>
 </body>
 </html>


### PR DESCRIPTION
Modernise this frontend to use the standard Slimmer Template layout, and make use of all components.

All changes visually diffed with `wraith`, the only regression being the expected from from the title component change (see below).

**Switch slimmer template to 'core_layout'**
`core_layout` is the default layout since Slimmer 9.0.0 [1], and apps
should be using it where possible.

The advantage over `header_footer_only` is that `core_layout` sets a
base grid/container for the main content, so apps don't need to
replicate it each time.

This switches the layout, but not overriding the default, and removes
the grid/container code specific to this app.

The SASS `grid_layout` isn't needed, but was including `measurements`
which is relied on else where.

[1] alphagov/slimmer#136

**Use 'title' component**
Use the component to avoid replicating page title styles locally, and
so we can roll changes out to page titles without needing to update
each app.

Although this change leaves 99% of the page as it was, it does introduce
a small visual diff; the "All metrics are recorded over the past 6 weeks"
line is pushed down slightly, as the title component has more bottom
margin.

I checked the design change with Rebecca Cottrell and she's happy with
the additional space anyway.