### PR TITLE
Configure asset_host in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,6 +45,8 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 


### PR DESCRIPTION
Use GOVUK_ASSET_HOST as is used in the production environment, and add
it to the development environment as its useful for development.