### PR TITLE
Only require 'ci/reporter/rake/rspec' in the useful environments

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,6 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
-require 'ci/reporter/rake/rspec'
+require 'ci/reporter/rake/rspec' if Rails.env.development? || Rails.env.test?
 
 Rails.application.load_tasks


### PR DESCRIPTION
This stops deployments breaking, as they try to precompile the assets,
and fail on loading this.