### PR TITLE
Change extracting part urls from the details of content

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -53,15 +53,18 @@ private
 
   def get_part_urls(content, slug)
     details = content.fetch("details")
-    part_urls = []
-    if details.key?("parts")
-      part_urls = details.fetch("parts") || []
-      if !part_urls.empty?
-        part_urls.map! {|part_url| URI(part_url["web_url"]).path }
-        part_urls.unshift(slug.insert(0, "/"))
+    return [] unless details.key?("parts")
+
+    parts = details.fetch("parts")
+
+    part_urls = parts.map! do |part|
+      if part.key?("web_url")
+        URI(part["web_url"]).path
+      else
+        "/#{slug}/#{part['slug']}"
       end
     end
-    return part_urls
+    part_urls.unshift(slug.insert(0, "/"))
   end
 
   def is_multipart(part_urls, document_type)


### PR DESCRIPTION
Multi-part content (e.g. guides) no longer appear to have a web_url in
the parts when fetched from the Content Stores. Instead the part urls
can be constructed from the slug of the part.

I've deployed this to integration, as I don't have the metadata-api locally to test with, and it seems to work.