### PR TITLE
Use the new buildProject options syntax in the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,5 @@
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  // 'false' parameter prevents the SASS from being linted
-  govuk.buildProject(false)
+  govuk.buildProject(sassLint: false)
 }


### PR DESCRIPTION
Replace the deprecated un-named parameter syntax with the new Map of options.