### PR TITLE
Remove Metadata API fallback

### DIFF
--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -48,6 +48,41 @@ feature "Info page" do
         meets_user_needs: [@apply_for_a_uk_visa_need.except(*fields_to_exclude)]
       }
     )
+
+    @apply_uk_visa_content_multipart = GovukSchemas::RandomExample.for_schema(
+      frontend_schema: "guide"
+    ).merge_and_validate(
+      title: "Apply for a UK visa",
+      links: {
+        meets_user_needs: [@apply_for_a_uk_visa_need.except(*fields_to_exclude)]
+      },
+      details: {
+        parts: [
+          {
+            slug: 'part-1',
+            title: 'Part 1',
+            body: 'Part 1',
+          },
+          {
+            slug: 'part-2',
+            title: 'Part 2',
+            body: 'Part 2',
+          },
+          {
+            slug: 'part-3',
+            title: 'Part 3',
+            body: 'Part 3',
+          },
+        ]
+      },
+    )
+
+    @apply_uk_visa_content_with_no_needs = random_content.merge_and_validate(
+      title: "Apply for a UK visa",
+      links: {
+        meets_user_needs: []
+      }
+    )
   end
 
   scenario "Understanding the needs of a page" do
@@ -83,19 +118,9 @@ feature "Info page" do
     expect(page).to have_text("Unique pageviews 25k per day")
   end
 
-  scenario "Seeing response for a smart answer" do
-    stub_metadata_api_has_slug('apply-uk-visa', metadata_api_response_for_smart_answer)
-    content_store_does_not_have_item('/apply-uk-visa')
-
-    visit "/info/apply-uk-visa"
-
-    # Check a smart answer is treated as a multipart format
-    expect(page).to have_text("Metrics across all pages")
-  end
-
   scenario "Seeing metrics for multi-part formats" do
     stub_metadata_api_has_slug('apply-uk-visa', metadata_api_response_for_multipart_artefact)
-    content_store_does_not_have_item('/apply-uk-visa')
+    content_store_has_item('/apply-uk-visa', @apply_uk_visa_content_multipart)
 
     visit "/info/apply-uk-visa"
 
@@ -167,8 +192,8 @@ feature "Info page" do
   end
 
   scenario "Seeing where there aren’t any recorded user needs" do
-    stub_metadata_api_has_slug('some-slug', metadata_api_response_with_no_needs)
-    content_store_does_not_have_item('/some-slug')
+    stub_metadata_api_has_slug('some-slug', metadata_api_response_for_apply_uk_visa)
+    content_store_has_item('/some-slug', @apply_uk_visa_content_with_no_needs)
 
     visit "/info/some-slug"
 
@@ -196,7 +221,7 @@ feature "Info page" do
 
   scenario "when a slug that needs encoding is provided" do
     stub_metadata_api_has_slug('government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8', metadata_api_response_for_apply_uk_visa)
-    content_store_does_not_have_item('/government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8')
+    content_store_has_item('/government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8', @apply_uk_visa_content)
 
     visit '/info/government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8'
 
@@ -213,19 +238,5 @@ feature "Info page" do
     expect(page).to have_text("non-EEA national")
     expect(page).to have_text("apply for a UK visa")
     expect(page).to have_text("I can come to the UK to visit, study or work")
-  end
-
-  scenario "doesn't show the user need when it isn't valid" do
-    stub_metadata_api_has_slug('apply-uk-visa', metadata_api_response_with_an_invalid_need)
-    content_store_does_not_have_item('/apply-uk-visa')
-
-    visit "/info/apply-uk-visa"
-
-    expect(page).to have_text("User needs and metrics")
-    expect(page).to_not have_text("non-EEA national")
-    expect(page).to_not have_text("apply for a UK visa")
-    expect(page).to_not have_text("I can come to the UK to visit, study or work")
-
-    expect(page).to have_text("There aren’t any validated needs for this page.")
   end
 end

--- a/spec/support/metadata_api_helpers.rb
+++ b/spec/support/metadata_api_helpers.rb
@@ -1,101 +1,91 @@
 module MetadataAPIHelpers
   def metadata_api_response_for_apply_uk_visa
-    {"artefact"=>
-      {"id"=>"https://contentapi.dev.gov.uk/apply-uk-visa.json",
-       "web_url"=>"https://www.dev.gov.uk/apply-uk-visa",
-       "title"=>"Apply for a UK visa",
-       "format"=>"transaction",
-       "details"=>
-        {"need_ids"=>["100126"],
-         "business_proposition"=>false,
-         "description"=>
-          "You can apply online for a UK visa to visit, work, study or join a family member or partner (eg spouse) already in the UK"}},
-     "needs"=>
-      [{"id"=>100126,
-        "role"=>"non-EEA national",
-        "goal"=>"apply for a UK visa",
-        "benefit"=>"I can come to the UK to visit, study or work",
-        "organisation_ids"=>["uk-visas-and-immigration"],
-        "organisations"=>
-         [{"id"=>"uk-visas-and-immigration",
-           "name"=>"UK Visas and Immigration",
-           "govuk_status"=>"live",
-           "abbreviation"=>"UKVI",
-           "parent_ids"=>["home-office"],
-           "child_ids"=>[]}],
-        "justifications"=>["It's something only government does"],
-        "impact"=>"Has consequences for the majority of your users",
-        "met_when"=>
-         ["Finds out how whether they're eligible",
-          "How to apply",
-          "What documents to provide"],
-        "status"=>{
-          "description"=>"valid",
-        },
-        "yearly_user_contacts"=>0,
-        "yearly_site_views"=>0,
-        "yearly_need_views"=>0,
-        "yearly_searches"=>0,
-        "other_evidence"=>"",
-        "legislation"=>"",
-        "applies_to_all_organisations"=>false,
-        "duplicate_of"=>0}],
-     "performance"=>
-      {"page_views"=>
-        [{"value"=>25000,
-          "path"=>"/apply-uk-visa",
-          "timestamp"=>"2014-07-03T00:00:00Z"},
-         {"value"=>24000,
-          "path"=>"/apply-uk-visa",
-          "timestamp"=>"2014-07-01T00:00:00Z"},
-         {"value"=>26000,
-          "path"=>"/apply-uk-visa",
-          "timestamp"=>"2014-07-02T00:00:00Z"}],
-       "problem_reports"=>
-        [{"value"=>1,
-          "path"=>"/apply-uk-visa",
-          "timestamp"=>"2014-07-01T00:00:00Z"},
-         {"value"=>2,
-          "path"=>"/apply-uk-visa",
-          "timestamp"=>"2014-07-02T00:00:00Z"},
-         {"value"=>3,
-          "path"=>"/apply-uk-visa",
-          "timestamp"=>"2014-07-03T00:00:00Z"},
-         {"value"=>0,
-          "path"=>"/apply-uk-visa",
-          "timestamp"=>"2014-07-04T00:00:00Z"},
-         {"value"=>1,
-          "path"=>"/apply-uk-visa",
-          "timestamp"=>"2014-07-05T00:00:00Z"},
-         {"value"=>0,
-          "path"=>"/apply-uk-visa",
-          "timestamp"=>"2014-07-06T00:00:00Z"},
-         {"value"=>0,
-          "path"=>"/apply-uk-visa",
-          "timestamp"=>"2014-07-07T00:00:00Z"}],
-       "searches"=>
-        [{"value"=>20,
-          "path"=>"/apply-uk-visa",
-          "timestamp"=>"2014-07-03T00:00:00Z"},
-         {"value"=>15,
-          "path"=>"/apply-uk-visa",
-          "timestamp"=>"2014-07-01T00:00:00Z"},
-         {"value"=>25,
-          "path"=>"/apply-uk-visa",
-          "timestamp"=>"2014-07-02T00:00:00Z"}],
-        "search_terms"=>
-         [{"TotalSearches"=>180,
-           "Keyword"=>"login"},
-          {"TotalSearches"=>100,
-           "Keyword"=>"spouse visa"}],
-         },
-     "_response_info"=>{"status"=>"ok"}}
-  end
-
-  def metadata_api_response_with_no_needs
-    metadata_api_response_for_apply_uk_visa.tap do |response|
-      response["needs"] = []
-    end
+    {
+      "performance" => {
+        "page_views" => [
+          {
+            "value" => 25000,
+            "path" => "/apply-uk-visa",
+            "timestamp" => "2014-07-03T00:00:00Z",
+          },
+          {
+            "value" => 24000,
+            "path" => "/apply-uk-visa",
+            "timestamp" => "2014-07-01T00:00:00Z",
+          },
+          {
+            "value" => 26000,
+            "path" => "/apply-uk-visa",
+            "timestamp" => "2014-07-02T00:00:00Z",
+          }
+        ],
+        "problem_reports" => [
+          {
+            "value" => 1,
+            "path" => "/apply-uk-visa",
+            "timestamp" => "2014-07-01T00:00:00Z",
+          },
+          {
+            "value" => 2,
+            "path" => "/apply-uk-visa",
+            "timestamp" => "2014-07-02T00:00:00Z",
+          },
+          {
+            "value" => 3,
+            "path" => "/apply-uk-visa",
+            "timestamp" => "2014-07-03T00:00:00Z",
+          },
+          {
+            "value" => 0,
+            "path" => "/apply-uk-visa",
+            "timestamp" => "2014-07-04T00:00:00Z",
+          },
+          {
+            "value" => 1,
+            "path" => "/apply-uk-visa",
+            "timestamp" => "2014-07-05T00:00:00Z",
+          },
+          {
+            "value" => 0,
+            "path" => "/apply-uk-visa",
+            "timestamp" => "2014-07-06T00:00:00Z",
+          },
+          {
+            "value" => 0,
+            "path" => "/apply-uk-visa",
+            "timestamp" => "2014-07-07T00:00:00Z",
+          }
+        ],
+        "searches" => [
+          {
+            "value" => 20,
+            "path" => "/apply-uk-visa",
+            "timestamp" => "2014-07-03T00:00:00Z",
+          },
+          {
+            "value" => 15,
+            "path" => "/apply-uk-visa",
+            "timestamp" => "2014-07-01T00:00:00Z",
+          },
+          {
+            "value" => 25,
+            "path" => "/apply-uk-visa",
+            "timestamp" => "2014-07-02T00:00:00Z",
+          }
+        ],
+        "search_terms" => [
+          {
+            "TotalSearches" => 180,
+            "Keyword" => "login",
+          },
+          {
+            "TotalSearches" => 100,
+            "Keyword" => "spouse visa",
+          }
+        ],
+      },
+      "_response_info" => { "status" => "ok" }
+    }
   end
 
   def metadata_api_response_with_no_performance_data
@@ -104,147 +94,208 @@ module MetadataAPIHelpers
     end
   end
 
-  def metadata_api_response_with_an_invalid_need
-    metadata_api_response_for_apply_uk_visa.tap do |response|
-      response["needs"].first["status"]["description"] = "proposed"
-    end
-  end
-
-  def metadata_api_response_for_smart_answer
-    metadata_api_response_for_apply_uk_visa.tap do |response|
-      response["artefact"]["format"] = 'smart-answer'
-    end
-  end
-
   def metadata_api_response_for_multipart_artefact
     metadata_api_response_for_apply_uk_visa.tap do |response|
-      response["artefact"]["details"]["parts"] = [
-        { "web_url" => response["artefact"]["web_url"] + "/part-1" },
-        { "web_url" => response["artefact"]["web_url"] + "/part-2" },
-        { "web_url" => response["artefact"]["web_url"] + "/part-3" },
-      ]
       response["performance"]["page_views"] += [
-        {"value"=>25000,
-         "path"=>"/apply-uk-visa/part-1",
-         "timestamp"=>"2014-07-03T00:00:00Z"},
-        {"value"=>26000,
-         "path"=>"/apply-uk-visa/part-1",
-         "timestamp"=>"2014-07-02T00:00:00Z"},
-        {"value"=>22000,
-         "path"=>"/apply-uk-visa/part-1",
-         "timestamp"=>"2014-07-01T00:00:00Z"},
-        {"value"=>10000,
-         "path"=>"/apply-uk-visa/part-2",
-         "timestamp"=>"2014-07-03T00:00:00Z"},
-        {"value"=>11000,
-         "path"=>"/apply-uk-visa/part-2",
-         "timestamp"=>"2014-07-02T00:00:00Z"},
-        {"value"=>12000,
-         "path"=>"/apply-uk-visa/part-2",
-         "timestamp"=>"2014-07-01T00:00:00Z"},
-        {"value"=>8000,
-         "path"=>"/apply-uk-visa/part-3",
-         "timestamp"=>"2014-07-03T00:00:00Z"},
-        {"value"=>7867,
-         "path"=>"/apply-uk-visa/part-3",
-         "timestamp"=>"2014-07-02T00:00:00Z"},
-        {"value"=>6325,
-         "path"=>"/apply-uk-visa/part-3",
-         "timestamp"=>"2014-07-01T00:00:00Z"},
+        {
+          "value" => 25000,
+          "path" => "/apply-uk-visa/part-1",
+          "timestamp" => "2014-07-03T00:00:00Z",
+        },
+        {
+          "value" => 26000,
+          "path" => "/apply-uk-visa/part-1",
+          "timestamp" => "2014-07-02T00:00:00Z",
+        },
+        {
+          "value" => 22000,
+          "path" => "/apply-uk-visa/part-1",
+          "timestamp" => "2014-07-01T00:00:00Z",
+        },
+        {
+          "value" => 10000,
+          "path" => "/apply-uk-visa/part-2",
+          "timestamp" => "2014-07-03T00:00:00Z",
+        },
+        {
+          "value" => 11000,
+          "path" => "/apply-uk-visa/part-2",
+          "timestamp" => "2014-07-02T00:00:00Z",
+        },
+        {
+          "value" => 12000,
+          "path" => "/apply-uk-visa/part-2",
+          "timestamp" => "2014-07-01T00:00:00Z",
+        },
+        {
+          "value" => 8000,
+          "path" => "/apply-uk-visa/part-3",
+          "timestamp" => "2014-07-03T00:00:00Z",
+        },
+        {
+          "value" => 7867,
+          "path" => "/apply-uk-visa/part-3",
+          "timestamp" => "2014-07-02T00:00:00Z",
+        },
+        {
+          "value" => 6325,
+          "path" => "/apply-uk-visa/part-3",
+          "timestamp" => "2014-07-01T00:00:00Z",
+        },
       ]
       response["performance"]["searches"] += [
-        {"value"=>4000,
-         "path"=>"/apply-uk-visa/part-1",
-         "timestamp"=>"2014-07-03T00:00:00Z"},
-        {"value"=>5000,
-         "path"=>"/apply-uk-visa/part-1",
-         "timestamp"=>"2014-07-02T00:00:00Z"},
-        {"value"=>6000,
-         "path"=>"/apply-uk-visa/part-1",
-         "timestamp"=>"2014-07-01T00:00:00Z"},
-        {"value"=>5000,
-         "path"=>"/apply-uk-visa/part-2",
-         "timestamp"=>"2014-07-03T00:00:00Z"},
-        {"value"=>5000,
-         "path"=>"/apply-uk-visa/part-2",
-         "timestamp"=>"2014-07-02T00:00:00Z"},
-        {"value"=>6000,
-         "path"=>"/apply-uk-visa/part-2",
-         "timestamp"=>"2014-07-01T00:00:00Z"},
-        {"value"=>8000,
-         "path"=>"/apply-uk-visa/part-3",
-         "timestamp"=>"2014-07-03T00:00:00Z"},
-        {"value"=>9000,
-         "path"=>"/apply-uk-visa/part-3",
-         "timestamp"=>"2014-07-02T00:00:00Z"},
-        {"value"=>10000,
-         "path"=>"/apply-uk-visa/part-3",
-         "timestamp"=>"2014-07-01T00:00:00Z"}
+        {
+          "value" => 4000,
+          "path" => "/apply-uk-visa/part-1",
+          "timestamp" => "2014-07-03T00:00:00Z",
+        },
+        {
+          "value" => 5000,
+          "path" => "/apply-uk-visa/part-1",
+          "timestamp" => "2014-07-02T00:00:00Z",
+        },
+        {
+          "value" => 6000,
+          "path" => "/apply-uk-visa/part-1",
+          "timestamp" => "2014-07-01T00:00:00Z",
+        },
+        {
+          "value" => 5000,
+          "path" => "/apply-uk-visa/part-2",
+          "timestamp" => "2014-07-03T00:00:00Z",
+        },
+        {
+          "value" => 5000,
+          "path" => "/apply-uk-visa/part-2",
+          "timestamp" => "2014-07-02T00:00:00Z",
+        },
+        {
+          "value" => 6000,
+          "path" => "/apply-uk-visa/part-2",
+          "timestamp" => "2014-07-01T00:00:00Z",
+        },
+        {
+          "value" => 8000,
+          "path" => "/apply-uk-visa/part-3",
+          "timestamp" => "2014-07-03T00:00:00Z",
+        },
+        {
+          "value" => 9000,
+          "path" => "/apply-uk-visa/part-3",
+          "timestamp" => "2014-07-02T00:00:00Z",
+        },
+        {
+          "value" => 10000,
+          "path" => "/apply-uk-visa/part-3",
+          "timestamp" => "2014-07-01T00:00:00Z"
+        },
       ]
       response["performance"]["problem_reports"] += [
-        {"value"=>1,
-          "path"=>"/apply-uk-visa/part-1",
-          "timestamp"=>"2014-07-01T00:00:00Z"},
-         {"value"=>2,
-          "path"=>"/apply-uk-visa/part-1",
-          "timestamp"=>"2014-07-02T00:00:00Z"},
-         {"value"=>3,
-          "path"=>"/apply-uk-visa/part-1",
-          "timestamp"=>"2014-07-03T00:00:00Z"},
-         {"value"=>0,
-          "path"=>"/apply-uk-visa/part-1",
-          "timestamp"=>"2014-07-04T00:00:00Z"},
-         {"value"=>1,
-          "path"=>"/apply-uk-visa/part-1",
-          "timestamp"=>"2014-07-05T00:00:00Z"},
-         {"value"=>0,
-          "path"=>"/apply-uk-visa/part-1",
-          "timestamp"=>"2014-07-06T00:00:00Z"},
-         {"value"=>0,
-          "path"=>"/apply-uk-visa/part-1",
-          "timestamp"=>"2014-07-07T00:00:00Z"},
-         {"value"=>1,
-          "path"=>"/apply-uk-visa/part-2",
-          "timestamp"=>"2014-07-01T00:00:00Z"},
-         {"value"=>2,
-          "path"=>"/apply-uk-visa/part-2",
-          "timestamp"=>"2014-07-02T00:00:00Z"},
-         {"value"=>3,
-          "path"=>"/apply-uk-visa/part-2",
-          "timestamp"=>"2014-07-03T00:00:00Z"},
-         {"value"=>3,
-          "path"=>"/apply-uk-visa/part-2",
-          "timestamp"=>"2014-07-04T00:00:00Z"},
-         {"value"=>1,
-          "path"=>"/apply-uk-visa/part-2",
-          "timestamp"=>"2014-07-05T00:00:00Z"},
-         {"value"=>5,
-          "path"=>"/apply-uk-visa/part-2",
-          "timestamp"=>"2014-07-06T00:00:00Z"},
-         {"value"=>0,
-          "path"=>"/apply-uk-visa/part-2",
-          "timestamp"=>"2014-07-07T00:00:00Z"},
-         {"value"=>1,
-          "path"=>"/apply-uk-visa/part-3",
-          "timestamp"=>"2014-07-01T00:00:00Z"},
-         {"value"=>1,
-          "path"=>"/apply-uk-visa/part-3",
-          "timestamp"=>"2014-07-02T00:00:00Z"},
-         {"value"=>3,
-          "path"=>"/apply-uk-visa/part-3",
-          "timestamp"=>"2014-07-03T00:00:00Z"},
-         {"value"=>4,
-          "path"=>"/apply-uk-visa/part-3",
-          "timestamp"=>"2014-07-04T00:00:00Z"},
-         {"value"=>1,
-          "path"=>"/apply-uk-visa/part-3",
-          "timestamp"=>"2014-07-05T00:00:00Z"},
-         {"value"=>2,
-          "path"=>"/apply-uk-visa/part-3",
-          "timestamp"=>"2014-07-06T00:00:00Z"},
-         {"value"=>0,
-          "path"=>"/apply-uk-visa/part-3",
-          "timestamp"=>"2014-07-07T00:00:00Z"},
+        {
+          "value" => 1,
+          "path" => "/apply-uk-visa/part-1",
+          "timestamp" => "2014-07-01T00:00:00Z",
+        },
+        {
+          "value" => 2,
+          "path" => "/apply-uk-visa/part-1",
+          "timestamp" => "2014-07-02T00:00:00Z",
+        },
+        {
+          "value" => 3,
+          "path" => "/apply-uk-visa/part-1",
+          "timestamp" => "2014-07-03T00:00:00Z",
+        },
+        {
+          "value" => 0,
+          "path" => "/apply-uk-visa/part-1",
+          "timestamp" => "2014-07-04T00:00:00Z",
+        },
+        {
+          "value" => 1,
+          "path" => "/apply-uk-visa/part-1",
+          "timestamp" => "2014-07-05T00:00:00Z",
+        },
+        {
+          "value" => 0,
+          "path" => "/apply-uk-visa/part-1",
+          "timestamp" => "2014-07-06T00:00:00Z",
+        },
+        {
+          "value" => 0,
+          "path" => "/apply-uk-visa/part-1",
+          "timestamp" => "2014-07-07T00:00:00Z",
+        },
+        {
+          "value" => 1,
+          "path" => "/apply-uk-visa/part-2",
+          "timestamp" => "2014-07-01T00:00:00Z",
+        },
+        {
+          "value" => 2,
+          "path" => "/apply-uk-visa/part-2",
+          "timestamp" => "2014-07-02T00:00:00Z",
+        },
+        {
+          "value" => 3,
+          "path" => "/apply-uk-visa/part-2",
+          "timestamp" => "2014-07-03T00:00:00Z",
+        },
+        {
+          "value" => 3,
+          "path" => "/apply-uk-visa/part-2",
+          "timestamp" => "2014-07-04T00:00:00Z",
+        },
+        {
+          "value" => 1,
+          "path" => "/apply-uk-visa/part-2",
+          "timestamp" => "2014-07-05T00:00:00Z",
+        },
+        {
+          "value" => 5,
+          "path" => "/apply-uk-visa/part-2",
+          "timestamp" => "2014-07-06T00:00:00Z",
+        },
+        {
+          "value" => 0,
+          "path" => "/apply-uk-visa/part-2",
+          "timestamp" => "2014-07-07T00:00:00Z",
+        },
+        {
+          "value" => 1,
+          "path" => "/apply-uk-visa/part-3",
+          "timestamp" => "2014-07-01T00:00:00Z",
+        },
+        {
+          "value" => 1,
+          "path" => "/apply-uk-visa/part-3",
+          "timestamp" => "2014-07-02T00:00:00Z",
+        },
+        {
+          "value" => 3,
+          "path" => "/apply-uk-visa/part-3",
+          "timestamp" => "2014-07-03T00:00:00Z",
+        },
+        {
+          "value" => 4,
+          "path" => "/apply-uk-visa/part-3",
+          "timestamp" => "2014-07-04T00:00:00Z",
+        },
+        {
+          "value" => 1,
+          "path" => "/apply-uk-visa/part-3",
+          "timestamp" => "2014-07-05T00:00:00Z",
+        },
+        {
+          "value" => 2,
+          "path" => "/apply-uk-visa/part-3",
+          "timestamp" => "2014-07-06T00:00:00Z",
+        },
+        {
+          "value" => 0,
+          "path" => "/apply-uk-visa/part-3",
+          "timestamp" => "2014-07-07T00:00:00Z",
+        },
       ]
     end
   end


### PR DESCRIPTION
[`govuk_content_api`](https://github.com/alphagov/govuk_content_api)
has been deprecated, and is being removed from the Metadata API
(https://github.com/alphagov/metadata-api/pull/35).

Since Metadata API will no longer attempt to fetch content from the
Content API, then we no longer need to fall back to the Metadata API.

### Trello

https://trello.com/c/o1TJIoUq/77-make-metadata-api-thus-info-frontend-no-longer-request-from-content-api