### PR TITLE
Exclude publishing_request_id field from tests

### DIFF
--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -40,6 +40,7 @@ feature "Info page" do
       need_ids
       format
       phase
+      publishing_request_id
     ) + supertype_fields
 
     @apply_uk_visa_content = random_content.merge_and_validate(


### PR DESCRIPTION
This is a new field which is going to be added to the Content Store, but it won't appear in the links hash, so we need to exclude it as we have done with the others.

[Trello Card](https://trello.com/c/JZ5Zabe9/702-remove-publishing-request-id-from-travel-advice-publisher-details-hash-2)