### PR TITLE
Return 404 when the item can't be retrived from the content store

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -6,6 +6,7 @@ require 'performance_data/metrics'
 class InfoController < ApplicationController
   include GdsApi::Helpers
   rescue_from GdsApi::ContentStore::ItemNotFound, with: :not_found
+  rescue_from GdsApi::HTTPGone, with: :not_found
   before_action :set_expiry, only: :show
 
   def show


### PR DESCRIPTION
This avoids erroring when the content store returns HTTP Gone.