### PR TITLE
Uses SSL version of performance URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'airbrake', '4.0.0'
 gem 'slimmer', '~> 9.0'
 gem 'plek', '1.11.0'
 gem 'govuk_frontend_toolkit', '1.6.1'
-gem 'gds-api-adapters', '47.0.0'
+gem 'gds-api-adapters', '47.1.1'
 
 group :development, :test do
   gem 'rspec-rails', '3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.2.1)
-    gds-api-adapters (47.0.0)
+    gds-api-adapters (47.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -245,7 +245,7 @@ DEPENDENCIES
   airbrake (= 4.0.0)
   capybara (= 2.4.1)
   ci_reporter_rspec
-  gds-api-adapters (= 47.0.0)
+  gds-api-adapters (= 47.1.1)
   govuk-lint
   govuk_frontend_toolkit (= 1.6.1)
   govuk_schemas (~> 2.1.0)

--- a/lib/performance_data/statistics.rb
+++ b/lib/performance_data/statistics.rb
@@ -9,7 +9,7 @@ module PerformanceData
                   :searches, :page_views, :problem_reports, :search_terms
 
     def initialize(content, slug)
-      @data_out = GdsApi::PerformancePlatform::DataOut.new("http://www.performance.service.gov.uk")
+      @data_out = GdsApi::PerformancePlatform::DataOut.new("https://www.performance.service.gov.uk")
       @slug = slug
       @part_urls = get_part_urls(content, slug)
       @is_multipart = @part_urls.any? || ALLOWED_DOC_TYPES.include?(content["document_type"])

--- a/lib/performance_data/test_helpers/statistics.rb
+++ b/lib/performance_data/test_helpers/statistics.rb
@@ -5,8 +5,6 @@ module PerformanceData
     module Statistics
       include GdsApi::TestHelpers::PerformancePlatform::DataOut
 
-      PP_DATA_OUT_ENDPOINT = "http://www.performance.service.gov.uk".freeze
-
       def stub_performance_platform_has_slug(slug, response)
         stub_search_terms(slug, response[:search_terms])
         stub_searches(slug, false, response[:searches])


### PR DESCRIPTION
For: https://trello.com/c/9JNitfXS/173-spike-info-pages

As part of the process to replace `metadata-api` in `info-frontend`, we're now using 4 new API calls in `gds-api-adapters` in order to talk to the `backdrop read API`. 

This used to be handled by `metadata-api`. 

However, the url path we were using for the performance endpoint was the non-secure version.

This commit replaces the performance url with the SSL enabled version (`http` -> `https`)

It also removes the `PP_DATA_OUT_ENDPOINT` from `test_helpers/statistics.rb` since it's not being used.