### PR TITLE
Formats nil values for performance stats

### DIFF
--- a/lib/performance_data/statistics.rb
+++ b/lib/performance_data/statistics.rb
@@ -75,7 +75,7 @@ module PerformanceData
         data.map do |item|
           item["values"].each do |value_item|
             stats << {
-               value: value_item[value_name],
+               value: value_item[value_name].to_i,
                path: item["pagePath"],
                timestamp: value_item["_start_at"].to_datetime
             }
@@ -129,6 +129,7 @@ module PerformanceData
       search_data = performance_data_for(searches, part_urls)
       problem_data = performance_data_for(problem_reports, part_urls)
       search_term_data = performance_data_for(search_terms, [])
+
       if is_multipart
         return PerformanceData::MultiPartMetrics.new(
           unique_pageviews: pageview_data,
@@ -169,12 +170,12 @@ module PerformanceData
           item["values"].each do |value_item|
             searches << {
                 timestamp: value_item["_start_at"].to_datetime,
-                value: value_item["searchUniques:sum"]
+                value: value_item["searchUniques:sum"].to_i
             }
           end
 
           stats << {
-              total_searches: item["searchUniques:sum"],
+              total_searches: item["searchUniques:sum"].to_i,
               keyword: item["searchKeyword"],
               searches: searches
           }

--- a/spec/models/performance_data/lead_metrics_spec.rb
+++ b/spec/models/performance_data/lead_metrics_spec.rb
@@ -208,7 +208,6 @@ module PerformanceData
         ] } }
       its(:problem_reports_weekly_average) { should eq(14) }
     end
-
   end
 
 end

--- a/spec/models/performance_data/statistics_spec.rb
+++ b/spec/models/performance_data/statistics_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+require 'performance_data/statistics'
+require 'performance_data/test_helpers/statistics'
+require 'gds_api/test_helpers/content_store'
+
+module PerformanceData
+  describe Statistics do
+    include PerformanceData::TestHelpers::Statistics
+    include GdsApi::TestHelpers::ContentStore
+
+    context "getting a response from the performance platform" do
+      context "with nil values" do
+        it "should replace nil values with zero" do
+          statistics = Statistics.new(apply_uk_visa_content, 'apply-uk-visa')
+
+          stub_performance_platform_has_slug('apply-uk-visa', performance_platform_response_with_nil_values)
+
+          problems = statistics.problem_reports
+          page_views = statistics.page_views
+          searches = statistics.searches
+          search_terms = statistics.search_terms
+
+          expect(problems.last[:value]).to eql(0)
+          expect(problems.last[:path]).to eql("/apply-uk-visa")
+
+          expect(page_views.last[:value]).to eql(0)
+          expect(page_views.last[:path]).to eql("/apply-uk-visa")
+
+          expect(searches.last[:value]).to eql(0)
+          expect(searches.last[:path]).to eql("/apply-uk-visa")
+
+          expect(search_terms.last[:total_searches]).to eql(0)
+          expect(search_terms.last[:searches].last[:value]).to eql(0)
+        end
+
+        it "should replace nil values with zero for multipart links" do
+          statistics = Statistics.new(apply_uk_visa_content_multipart, 'apply-uk-visa')
+
+          stub_performance_platform_has_slug_multipart('/apply-uk-visa', performance_platform_response_for_multipart_with_nil_values)
+
+          problems = statistics.problem_reports
+          page_views = statistics.page_views
+          searches = statistics.searches
+          # there is no multipart version of search-terms
+
+          expect(problems.last[:value]).to eql(0)
+          expect(problems.last[:path]).to eql("/apply-uk-visa/part-3")
+
+          expect(page_views.last[:value]).to eql(0)
+          expect(page_views.last[:path]).to eql("/apply-uk-visa/part-3")
+
+          expect(searches.last[:value]).to eql(0)
+          expect(searches.last[:path]).to eql("/apply-uk-visa/part-3")
+        end
+      end
+    end
+
+    def apply_uk_visa_content
+      GovukSchemas::RandomExample.for_schema(
+        frontend_schema: "specialist_document"
+      ).merge_and_validate(
+        title: "Apply for a UK visa",
+        links: {
+            meets_user_needs: [apply_for_a_uk_visa_need]
+        }
+      )
+    end
+
+    def apply_uk_visa_content_multipart
+      GovukSchemas::RandomExample.for_schema(
+        frontend_schema: "guide"
+      ).merge_and_validate(
+        title: "Apply for a UK visa 1",
+        links: {
+            meets_user_needs: [apply_for_a_uk_visa_need]
+        },
+        "details" => {
+            "parts" => [
+                {
+                    "slug" => 'part-1',
+                    "title" => 'Part 1',
+                    "body" => 'Part 1',
+                },
+                {
+                    "slug" => 'part-2',
+                    "title" => 'Part 2',
+                    "body" => 'Part 2',
+                },
+                {
+                    "slug" => 'part-3',
+                    "title" => 'Part 3',
+                    "body" => 'Part 3',
+                },
+            ]
+        },
+      )
+    end
+
+    def apply_for_a_uk_visa_need
+      random_need = GovukSchemas::RandomExample.for_schema(
+        frontend_schema: "need"
+      ).merge_and_validate(
+        "details" => {
+            "role" => "As a non-EEA national",
+            "goal" => "I need to apply for a UK visa",
+            "benefit" => "So that I can come to the UK to visit, study or work",
+            "justifications" => ["It's something only government does"],
+            "met_when" => [
+                "Finds out how whether they're eligible",
+                "How to apply",
+                "What documents to provide"
+            ],
+        }
+      )
+
+      clean_up_need(random_need)
+    end
+
+    def clean_up_need(need)
+      supertype_fields = need.keys.select { |field| field.end_with? "supertype" }
+      fields_to_exclude = %w(
+        rendering_app
+        withdrawn_notice
+        last_edited_at
+        updated_at
+        first_published_at
+        publishing_app
+        need_ids
+        format
+        phase
+        publishing_request_id
+        navigation_document_supertype
+        government_document_supertype
+        email_document_supertype
+      ) + supertype_fields
+      need.except(*fields_to_exclude)
+    end
+  end
+end

--- a/spec/support/statistics_helpers.rb
+++ b/spec/support/statistics_helpers.rb
@@ -8,12 +8,30 @@ module StatisticsHelpers
     }
   end
 
+  def performance_platform_response_with_nil_values
+    {
+        search_terms: performance_platform_response_for_search_terms_with_nil_values,
+        searches: performance_platform_response_for_searches_with_nil_values,
+        page_views: performance_platform_response_for_page_views_with_nil_values,
+        problem_reports: performance_platform_response_for_problem_reports_with_nil_values
+    }
+  end
+
   def performance_platform_response_for_multipart_artefact
     {
         search_terms: performance_platform_response_for_search_terms,
         searches: performance_platform_response_for_multipart_searches,
         page_views: performance_platform_response_for_multipart_page_views,
         problem_reports: performance_platform_response_for_multipart_problem_reports
+    }
+  end
+
+  def performance_platform_response_for_multipart_with_nil_values
+    {
+        search_terms: performance_platform_response_for_search_terms_with_nil_values,
+        searches: performance_platform_response_for_multipart_searches_with_nil_values,
+        page_views: performance_platform_response_for_multipart_page_views_with_nil_values,
+        problem_reports: performance_platform_response_for_multipart_problem_reports_with_nil_values
     }
   end
 
@@ -182,6 +200,79 @@ module StatisticsHelpers
                          {
                              _count: 3,
                              'searchUniques:sum': 15,
+                             _end_at: '2014-09-04T00:00:00+00:00',
+                             _start_at: '2014-09-03T00:00:00+00:00'
+                         }]
+            }
+        ]
+    }
+  end
+
+  def performance_platform_response_for_searches_with_nil_values
+    {
+        data: [
+            {
+                pagePath: '/apply-uk-visa',
+                values: [
+                    {
+                        _count: 6,
+                        _end_at: '2014-09-07T00:00:00+00:00',
+                        _start_at: '2014-09-06T00:00:00+00:00',
+                        'searchUniques:sum': nil
+                    }
+                ]
+            }
+        ]
+    }
+  end
+
+  def performance_platform_response_for_page_views_with_nil_values
+    {
+        data: [
+            {
+                pagePath: '/apply-uk-visa',
+                values: [
+                    {
+                        _count: 3,
+                        _end_at: '2014-07-03T00:00:00+00:00',
+                        _start_at: '2014-07-02T00:00:00+00:00',
+                        'uniquePageviews:sum': nil
+                    }
+                ]
+            }
+        ]
+    }
+  end
+
+  def performance_platform_response_for_problem_reports_with_nil_values
+    {
+        data: [
+            {
+                pagePath: '/apply-uk-visa',
+                values: [
+                    {
+                        _count: 5,
+                        _end_at: '2014-09-05T00:00:00+00:00',
+                        _start_at: '2014-09-04T00:00:00+00:00',
+                        'total:sum': nil
+                    }
+                ]
+            }
+        ]
+    }
+  end
+
+  def performance_platform_response_for_search_terms_with_nil_values
+    {
+        data: [
+            {
+                _count: 4,
+                _group_count: 4,
+                searchKeyword: 's2s',
+                'searchUniques:sum': nil,
+                values: [{
+                             _count: 3,
+                             'searchUniques:sum': nil,
                              _end_at: '2014-09-04T00:00:00+00:00',
                              _start_at: '2014-09-03T00:00:00+00:00'
                          }]
@@ -403,6 +494,126 @@ module StatisticsHelpers
                 ]
             }
         ]
+    end
+  end
+
+  def performance_platform_response_for_multipart_searches_with_nil_values
+    performance_platform_response_for_searches.tap do |response|
+      response[:data] += [
+          {
+              pagePath: '/apply-uk-visa/part-1',
+              values: [
+                  {
+                      _count: 3,
+                      _end_at: '2014-09-01T00:00:00+00:00',
+                      _start_at: '2014-09-01T00:00:00+00:00',
+                      'searchUniques:sum': nil
+                  }
+              ]
+          },
+          {
+              pagePath: '/apply-uk-visa/part-2',
+              values: [
+                  {
+                      _count: 5,
+                      _end_at: '2014-09-04T00:00:00+00:00',
+                      _start_at: '2014-09-03T00:00:00+00:00',
+                      'searchUniques:sum': nil
+                  }
+              ]
+          },
+          {
+              pagePath: '/apply-uk-visa/part-3',
+              values: [
+                  {
+                      _count: 1,
+                      _end_at: '2014-09-02T00:00:00+00:00',
+                      _start_at: '2014-09-01T00:00:00+00:00',
+                      'searchUniques:sum': nil
+                  }
+              ]
+          }
+      ]
+    end
+  end
+
+  def performance_platform_response_for_multipart_problem_reports_with_nil_values
+    performance_platform_response_for_problem_reports.tap do |response|
+      response[:data] += [
+          {
+              pagePath: '/apply-uk-visa/part-1',
+              values: [
+                  {
+                      _count: 4,
+                      _end_at: '2014-09-03T00:00:00+00:00',
+                      _start_at: '2014-09-02T00:00:00+00:00',
+                      'total:sum': nil
+                  }
+              ]
+          },
+          {
+              pagePath: '/apply-uk-visa/part-2',
+              values: [
+                  {
+                      _count: 4,
+                      _end_at: '2014-09-03T00:00:00+00:00',
+                      _start_at: '2014-09-02T00:00:00+00:00',
+                      'total:sum': nil
+                  }
+              ]
+          },
+          {
+              pagePath: '/apply-uk-visa/part-3',
+              values: [
+                  {
+                      _count: 4,
+                      _end_at: '2014-09-03T00:00:00+00:00',
+                      _start_at: '2014-09-02T00:00:00+00:00',
+                      'total:sum': nil
+                  }
+              ]
+          }
+      ]
+    end
+  end
+
+  def performance_platform_response_for_multipart_page_views_with_nil_values
+    performance_platform_response_for_page_views.tap do |response|
+      response[:data] += [
+          {
+              pagePath: '/apply-uk-visa/part-1',
+              values: [
+                  {
+                      _count: 5,
+                      _end_at: '2014-07-03T00:00:00+00:00',
+                      _start_at: '2014-07-02T00:00:00+00:00',
+                      'uniquePageviews:sum': nil
+                  }
+              ]
+          },
+          {
+              pagePath: '/apply-uk-visa/part-2',
+              values: [
+                  {
+                      _count: 3,
+                      _end_at: '2014-07-03T00:00:00+00:00',
+                      _start_at: '2014-07-02T00:00:00+00:00',
+                      'uniquePageviews:sum': nil
+                  }
+              ]
+          },
+          {
+              pagePath: '/apply-uk-visa/part-3',
+              values: [
+                  {
+                      _count: 1,
+                      _end_at: '2014-07-03T00:00:00+00:00',
+                      _start_at: '2014-07-02T00:00:00+00:00',
+                      'uniquePageviews:sum': nil
+                  }
+              ]
+          }
+      ]
     end
   end
 end


### PR DESCRIPTION
This is a follow up to https://github.com/alphagov/info-frontend/pull/71 and https://github.com/alphagov/info-frontend/pull/72 where we are in the process of removing metadata-api from info-frontend.

In order to do this, we have moved the api calls handled by `metadata-api` into `gds-api-adapters`. The api calls will be passed on by `gds-api-adapters` to the `backend read api`. The response is parsed and rendered by `info-frontend`.

This commit will take into account the possibility that the response we receive from `backend read API` contains `nil` in the `value` param. This was a use case that was not taken into account before, so there is now a test to check that we can handle it.

Previously, the formatting of nil values was handled by `metadata-api` in here: https://github.com/alphagov/metadata-api/commit/81e2b670cd2defd94954cfc561bf929035826a8e#diff-931132c428c386579ddf11c313d82b28R220