### PR TITLE
Format performance slug before doing request

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -10,9 +10,9 @@ class InfoController < ApplicationController
   before_action :set_expiry, only: :show
 
   def show
-    @slug = URI.encode(params[:slug])
+    @slug = parse_slug
 
-    @content = content_store.content_item("/#{@slug}").to_h
+    @content = content_store.content_item(@slug).to_h
     @needs = @content["links"]["meets_user_needs"]
 
     begin
@@ -28,6 +28,11 @@ class InfoController < ApplicationController
   end
 
 private
+
+  def parse_slug
+    slug = URI.encode(params[:slug])
+    slug[0] != '/' ? "/#{slug}" : slug
+  end
 
   def not_found
     response.headers[Slimmer::Headers::SKIP_HEADER] = "1"

--- a/lib/performance_data/statistics.rb
+++ b/lib/performance_data/statistics.rb
@@ -195,10 +195,10 @@ module PerformanceData
         if part.key?("web_url")
           URI(part["web_url"]).path
         else
-          "/#{slug}/#{part['slug']}"
+          "#{slug}/#{part['slug']}"
         end
       end
-      part_urls.unshift(slug.insert(0, "/"))
+      part_urls.unshift(slug)
     end
 
     # For individual page metrics, we don't include search terms

--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -87,7 +87,7 @@ feature "Info page" do
   end
 
   scenario "Understanding the needs of a page" do
-    stub_performance_platform_has_slug('apply-uk-visa', performance_platform_response_for_apply_uk_visa)
+    stub_performance_platform_has_slug('/apply-uk-visa', performance_platform_response_for_apply_uk_visa)
     content_store_has_item('/apply-uk-visa', @apply_uk_visa_content)
 
     visit "/info/apply-uk-visa"
@@ -111,7 +111,7 @@ feature "Info page" do
   end
 
   scenario "Seeing how many visits are made to a page" do
-    stub_performance_platform_has_slug('apply-uk-visa', performance_platform_response_for_apply_uk_visa)
+    stub_performance_platform_has_slug('/apply-uk-visa', performance_platform_response_for_apply_uk_visa)
     content_store_has_item('/apply-uk-visa', @apply_uk_visa_content)
 
     visit "/info/apply-uk-visa"
@@ -166,7 +166,7 @@ feature "Info page" do
   end
 
   scenario "Seeing how many users are leaving via the site search" do
-    stub_performance_platform_has_slug('apply-uk-visa', performance_platform_response_for_apply_uk_visa)
+    stub_performance_platform_has_slug('/apply-uk-visa', performance_platform_response_for_apply_uk_visa)
     content_store_has_item('/apply-uk-visa', @apply_uk_visa_content)
 
     visit "/info/apply-uk-visa"
@@ -175,7 +175,7 @@ feature "Info page" do
   end
 
   scenario "Seeing how problem reports are left" do
-    stub_performance_platform_has_slug('apply-uk-visa', performance_platform_response_for_apply_uk_visa)
+    stub_performance_platform_has_slug('/apply-uk-visa', performance_platform_response_for_apply_uk_visa)
     content_store_has_item('/apply-uk-visa', @apply_uk_visa_content)
 
     visit "/info/apply-uk-visa"
@@ -184,7 +184,7 @@ feature "Info page" do
   end
 
   scenario "Seeing what terms users are searching for" do
-    stub_performance_platform_has_slug('apply-uk-visa', performance_platform_response_for_apply_uk_visa)
+    stub_performance_platform_has_slug('/apply-uk-visa', performance_platform_response_for_apply_uk_visa)
     content_store_has_item('/apply-uk-visa', @apply_uk_visa_content)
 
     visit "/info/apply-uk-visa"
@@ -194,7 +194,7 @@ feature "Info page" do
   end
 
   scenario "Seeing where there aren’t any recorded user needs" do
-    stub_performance_platform_has_slug('some-slug', performance_platform_response_for_apply_uk_visa)
+    stub_performance_platform_has_slug('/some-slug', performance_platform_response_for_apply_uk_visa)
     content_store_has_item('/some-slug', @apply_uk_visa_content_with_no_needs)
 
     visit "/info/some-slug"
@@ -203,7 +203,7 @@ feature "Info page" do
   end
 
   scenario "When there isn't any performance data available" do
-    stub_performance_platform_has_slug('some-slug', performance_platform_response_with_no_performance_data)
+    stub_performance_platform_has_slug('/some-slug', performance_platform_response_with_no_performance_data)
     content_store_has_item('/some-slug', @apply_uk_visa_content)
 
     visit "/info/some-slug"
@@ -213,7 +213,7 @@ feature "Info page" do
   end
 
   scenario "When no information is available for a given slug" do
-    stub_performance_platform_has_no_data_for_slug('slug-without-info')
+    stub_performance_platform_has_no_data_for_slug('/slug-without-info')
     content_store_does_not_have_item('/slug-without-info')
 
     visit "/info/slug-without-info"
@@ -222,7 +222,7 @@ feature "Info page" do
   end
 
   scenario "when a slug that needs encoding is provided" do
-    stub_performance_platform_has_slug('government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8', performance_platform_response_for_apply_uk_visa)
+    stub_performance_platform_has_slug('/government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8', performance_platform_response_for_apply_uk_visa)
     content_store_has_item('/government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8', @apply_uk_visa_content)
 
     visit '/info/government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8'
@@ -231,7 +231,7 @@ feature "Info page" do
   end
 
   scenario "shows the user need when it's valid" do
-    stub_performance_platform_has_slug('apply-uk-visa', performance_platform_response_for_apply_uk_visa)
+    stub_performance_platform_has_slug('/apply-uk-visa', performance_platform_response_for_apply_uk_visa)
     content_store_has_item('/apply-uk-visa', @apply_uk_visa_content)
 
     visit "/info/apply-uk-visa"

--- a/spec/models/performance_data/statistics_spec.rb
+++ b/spec/models/performance_data/statistics_spec.rb
@@ -11,9 +11,9 @@ module PerformanceData
     context "getting a response from the performance platform" do
       context "with nil values" do
         it "should replace nil values with zero" do
-          statistics = Statistics.new(apply_uk_visa_content, 'apply-uk-visa')
+          statistics = Statistics.new(apply_uk_visa_content, '/apply-uk-visa')
 
-          stub_performance_platform_has_slug('apply-uk-visa', performance_platform_response_with_nil_values)
+          stub_performance_platform_has_slug('/apply-uk-visa', performance_platform_response_with_nil_values)
 
           problems = statistics.problem_reports
           page_views = statistics.page_views
@@ -34,7 +34,7 @@ module PerformanceData
         end
 
         it "should replace nil values with zero for multipart links" do
-          statistics = Statistics.new(apply_uk_visa_content_multipart, 'apply-uk-visa')
+          statistics = Statistics.new(apply_uk_visa_content_multipart, '/apply-uk-visa')
 
           stub_performance_platform_has_slug_multipart('/apply-uk-visa', performance_platform_response_for_multipart_with_nil_values)
 


### PR DESCRIPTION
The statistics class was introduced to take over the duties from metadata-api: fetch data from the performance platform and format the data. However, it wasn't being strict about checking whether the page we're fetching performance data for has their slug starting with a "/".

It's not longer assuming the data it's receiving is correct and always makes sure to add the forward slash to the slug before sending the request to the performance platform.

The missing slash meant that for multi-part pages, the data would not be fetched correctly.

Initial transition from metadata-api to just using the `Statistics` class in `info-frontend` was carried out for: https://trello.com/c/9JNitfXS/173-spike-info-pages