### PR TITLE
Improvements to statistics

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -16,11 +16,7 @@ class InfoController < ApplicationController
     @needs = @content["links"]["meets_user_needs"]
 
     begin
-      statistics = PerformanceData::Statistics.new(@content, @slug)
-
-      @is_multipart = statistics.is_multipart
-      @lead_metrics = statistics.lead_metrics
-      @per_page_metrics = statistics.per_page_metrics
+      @statistics = PerformanceData::Statistics.new(@content, @slug)
     rescue StandardError => e
       logger.error "Performance data related error for #{@slug}"
       logger.error e.message

--- a/app/views/info/_lead_metrics.html.erb
+++ b/app/views/info/_lead_metrics.html.erb
@@ -1,19 +1,19 @@
 <section id="lead-metrics">
   <% if lead_metrics %>
-    <%- if @is_multipart %>
+    <%- if multipart %>
     <h2>Metrics across all pages</h2>
     <%- end %>
     <div class="metrics-panel">
       <div class="lead-metric">
         <h2>Unique pageviews</h2>
         <p class="count">
-            <%= human_readable_number(lead_metrics.unique_pageviews_average) %>
+          <%= human_readable_number(lead_metrics.unique_pageviews_average) %>
           <span class="unit">per day</span>
         </p>
       </div>
       <div class="wide-lead-metric">
         <h2>Searches started
-          <%- if !@is_multipart %>
+          <%- if !multipart %>
             from this page
           <%- end %>
         </h2>

--- a/app/views/info/_needs.html.erb
+++ b/app/views/info/_needs.html.erb
@@ -1,6 +1,6 @@
 <section id="needs">
   <header class="needs-heading">
-    <h1>Why <%- if is_multipart %> are these pages <%- else %> is this page <%- end %> on GOV.UK?</h1>
+    <h1>Why <%- if multipart %> are these pages <%- else %> is this page <%- end %> on GOV.UK?</h1>
   </header>
   <div class="individual-need">
     <% if needs.present? %>

--- a/app/views/info/show.html.erb
+++ b/app/views/info/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title do "Information about “#{@content["title"]}”" end %>
 
 <%= render partial: "content", locals: { content: @content } %>
-<%= render partial: "lead_metrics", locals: { lead_metrics: @lead_metrics, is_multipart: @is_multipart } %>
-<%= render partial: "per_page_metrics", locals: { per_page_metrics: @per_page_metrics } %>
-<%= render partial: "needs", locals: { needs: @needs, is_multipart: @is_multipart } %>
+<%= render partial: "lead_metrics", locals: { lead_metrics: @statistics.lead_metrics, multipart: @statistics.multipart? } %>
+<%= render partial: "per_page_metrics", locals: { per_page_metrics: @statistics.per_page_metrics } %>
+<%= render partial: "needs", locals: { needs: @needs, multipart: @statistics.multipart? } %>

--- a/lib/performance_data/statistics.rb
+++ b/lib/performance_data/statistics.rb
@@ -191,13 +191,7 @@ module PerformanceData
 
       parts = details.fetch("parts")
 
-      part_urls = parts.map! do |part|
-        if part.key?("web_url")
-          URI(part["web_url"]).path
-        else
-          "#{slug}/#{part['slug']}"
-        end
-      end
+      part_urls = parts.map! { |part| "#{slug}/#{part['slug']}" }
       part_urls.unshift(slug)
     end
 

--- a/lib/performance_data/statistics.rb
+++ b/lib/performance_data/statistics.rb
@@ -1,38 +1,147 @@
 require 'json'
 require 'gds_api/performance_platform/data_out'
+require 'performance_data/metrics'
 
 module PerformanceData
   class Statistics
     ALLOWED_DOC_TYPES = %w('smart_answer', 'simple_smart_answer').freeze
 
-    attr_accessor :data_out, :slug, :part_urls, :is_multipart,
-                  :searches, :page_views, :problem_reports, :search_terms
+    attr_accessor :per_page_metrics, :lead_metrics
 
     def initialize(content, slug)
-      @data_out = GdsApi::PerformancePlatform::DataOut.new("https://www.performance.service.gov.uk")
       @slug = slug
-      @part_urls = get_part_urls(content, slug)
-      @is_multipart = @part_urls.any? || ALLOWED_DOC_TYPES.include?(content["document_type"])
+      @content = content
+      @per_page_metrics = calculate_per_page_metrics
+      @lead_metrics = calculate_lead_metrics
+    end
+
+    def data_out
+      @data_out ||= GdsApi::PerformancePlatform::DataOut.new("https://www.performance.service.gov.uk")
+    end
+
+    def part_urls
+      @part_urls ||= get_part_urls(@content, @slug)
+    end
+
+    def multipart?
+      @multipart ||= @part_urls.any? || ALLOWED_DOC_TYPES.include?(@content["document_type"])
     end
 
     def searches
       @searches ||= begin
-        response = data_out.searches(slug, @is_multipart)
+        response = data_out.searches(@slug, multipart?)
         parse_values(response, "searchUniques:sum")
       end
     end
 
     def page_views
       @page_views ||= begin
-        response = data_out.page_views(slug, @is_multipart)
+        response = data_out.page_views(@slug, multipart?)
         parse_values(response, "uniquePageviews:sum")
       end
     end
 
     def problem_reports
       @problem_reports ||= begin
-        response = data_out.problem_reports(slug, @is_multipart)
+        response = data_out.problem_reports(@slug, multipart?)
         parse_values(response, "total:sum")
+      end
+    end
+
+    # Parses JSON response for the search-terms API call
+    #
+    # A response example would look like this:
+    #
+    # data = {
+    #     "data": [
+    #         {
+    #             "_count": 8,
+    #             "_group_count": 8,
+    #             "searchKeyword": "employer access",
+    #             "searchUniques:sum": 100,
+    #             "values": [{
+    #                            "_count": 1,
+    #                            "searchUniques:sum": 126,
+    #                            "_end_at": "2014-09-02T00:00:00+00:00",
+    #                            "_start_at": "2014-09-01T00:00:00+00:00"
+    #                        }]
+    #         }
+    #     ]
+    # }
+    #
+    # The method would parse that response into:
+    # [
+    #   {
+    #     total_searches: 100,
+    #     keyword: "employer access",
+    #     searches: [{
+    #                 timestamp: "2014-09-01T00:00:00Z",
+    #                 value: 126
+    #               }]
+    #   }
+    # ]
+    #
+
+    def search_terms
+      @search_terms ||= begin
+        response = data_out.search_terms(@slug)
+        stats = []
+
+        if response.raw_response_body != 'null'
+          response = response.to_h
+          response["data"].map do |item|
+            searches = []
+            item["values"].each do |value_item|
+              searches << {
+                  timestamp: value_item["_start_at"].to_datetime,
+                  value: value_item["searchUniques:sum"].to_i
+              }
+            end
+
+            stats << {
+                total_searches: item["searchUniques:sum"].to_i,
+                keyword: item["searchKeyword"],
+                searches: searches
+            }
+          end
+        end
+
+        stats
+      end
+    end
+
+  private
+
+    def calculate_per_page_metrics
+      per_page_metrics = {}
+
+      part_urls.each do |path|
+        per_page_metrics[path] = per_page_metrics_for(path)
+      end
+
+      per_page_metrics
+    end
+
+    def calculate_lead_metrics
+      pageview_data = performance_data_for(page_views, part_urls)
+      search_data = performance_data_for(searches, part_urls)
+      problem_data = performance_data_for(problem_reports, part_urls)
+      search_term_data = performance_data_for(search_terms, [])
+
+      if multipart?
+        return PerformanceData::MultiPartMetrics.new(
+          unique_pageviews: pageview_data,
+          exits_via_search: search_data,
+          problem_reports: problem_data,
+          search_terms: search_term_data
+        )
+      else
+        return PerformanceData::Metrics.new(
+          unique_pageviews: pageview_data,
+          exits_via_search: search_data,
+          problem_reports: problem_data,
+          search_terms: search_term_data
+        )
       end
     end
 
@@ -75,110 +184,11 @@ module PerformanceData
         data.map do |item|
           item["values"].each do |value_item|
             stats << {
-               value: value_item[value_name].to_i,
-               path: item["pagePath"],
-               timestamp: value_item["_start_at"].to_datetime
+              value: value_item[value_name].to_i,
+              path: item["pagePath"],
+              timestamp: value_item["_start_at"].to_datetime
             }
           end
-        end
-      end
-
-      stats
-    end
-
-    # Parses JSON response for the search-terms API call
-    #
-    # A response example would look like this:
-    #
-    # data = {
-    #     "data": [
-    #         {
-    #             "_count": 8,
-    #             "_group_count": 8,
-    #             "searchKeyword": "employer access",
-    #             "searchUniques:sum": 100,
-    #             "values": [{
-    #                            "_count": 1,
-    #                            "searchUniques:sum": 126,
-    #                            "_end_at": "2014-09-02T00:00:00+00:00",
-    #                            "_start_at": "2014-09-01T00:00:00+00:00"
-    #                        }]
-    #         }
-    #     ]
-    # }
-    #
-    # The method would parse that response into:
-    # [
-    #   {
-    #     total_searches: 100,
-    #     keyword: "employer access",
-    #     searches: [{
-    #                 timestamp: "2014-09-01T00:00:00Z",
-    #                 value: 126
-    #               }]
-    #   }
-    # ]
-    #
-
-    def search_terms
-      @search_terms ||= parse_search_terms
-    end
-
-    def lead_metrics
-      pageview_data = performance_data_for(page_views, part_urls)
-      search_data = performance_data_for(searches, part_urls)
-      problem_data = performance_data_for(problem_reports, part_urls)
-      search_term_data = performance_data_for(search_terms, [])
-
-      if is_multipart
-        return PerformanceData::MultiPartMetrics.new(
-          unique_pageviews: pageview_data,
-          exits_via_search: search_data,
-          problem_reports: problem_data,
-          search_terms: search_term_data
-        )
-      else
-        return PerformanceData::Metrics.new(
-          unique_pageviews: pageview_data,
-          exits_via_search: search_data,
-          problem_reports: problem_data,
-          search_terms: search_term_data
-        )
-      end
-    end
-
-    def per_page_metrics
-      per_page_metrics = {}
-
-      part_urls.each do |path|
-        per_page_metrics[path] = per_page_metrics_for(path)
-      end
-
-      per_page_metrics
-    end
-
-  private
-
-    def parse_search_terms
-      response = data_out.search_terms(slug)
-      stats = []
-
-      if response.raw_response_body != 'null'
-        response = response.to_h
-        response["data"].map do |item|
-          searches = []
-          item["values"].each do |value_item|
-            searches << {
-                timestamp: value_item["_start_at"].to_datetime,
-                value: value_item["searchUniques:sum"].to_i
-            }
-          end
-
-          stats << {
-              total_searches: item["searchUniques:sum"].to_i,
-              keyword: item["searchKeyword"],
-              searches: searches
-          }
         end
       end
 

--- a/lib/performance_data/test_helpers/statistics.rb
+++ b/lib/performance_data/test_helpers/statistics.rb
@@ -13,12 +13,12 @@ module PerformanceData
       end
 
       def stub_performance_platform_has_slug_multipart(slug, response)
-        is_multipart = true
+        multipart = true
 
         stub_search_terms(slug, response[:search_terms])
-        stub_searches(slug, is_multipart, response[:searches])
-        stub_page_views(slug, is_multipart, response[:page_views])
-        stub_problem_reports(slug, is_multipart, response[:problem_reports])
+        stub_searches(slug, multipart, response[:searches])
+        stub_page_views(slug, multipart, response[:page_views])
+        stub_problem_reports(slug, multipart, response[:problem_reports])
       end
 
       def stub_performance_platform_has_no_data_for_slug(slug)

--- a/spec/models/performance_data/statistics_spec.rb
+++ b/spec/models/performance_data/statistics_spec.rb
@@ -11,46 +11,38 @@ module PerformanceData
     context "getting a response from the performance platform" do
       context "with nil values" do
         it "should replace nil values with zero" do
-          statistics = Statistics.new(apply_uk_visa_content, '/apply-uk-visa')
-
           stub_performance_platform_has_slug('/apply-uk-visa', performance_platform_response_with_nil_values)
 
-          problems = statistics.problem_reports
-          page_views = statistics.page_views
-          searches = statistics.searches
-          search_terms = statistics.search_terms
+          statistics = Statistics.new(apply_uk_visa_content, '/apply-uk-visa')
 
-          expect(problems.last[:value]).to eql(0)
-          expect(problems.last[:path]).to eql("/apply-uk-visa")
+          expect(statistics.problem_reports.last[:value]).to eql(0)
+          expect(statistics.problem_reports.last[:path]).to eql("/apply-uk-visa")
 
-          expect(page_views.last[:value]).to eql(0)
-          expect(page_views.last[:path]).to eql("/apply-uk-visa")
+          expect(statistics.page_views.last[:value]).to eql(0)
+          expect(statistics.page_views.last[:path]).to eql("/apply-uk-visa")
 
-          expect(searches.last[:value]).to eql(0)
-          expect(searches.last[:path]).to eql("/apply-uk-visa")
+          expect(statistics.searches.last[:value]).to eql(0)
+          expect(statistics.searches.last[:path]).to eql("/apply-uk-visa")
 
-          expect(search_terms.last[:total_searches]).to eql(0)
-          expect(search_terms.last[:searches].last[:value]).to eql(0)
+          expect(statistics.search_terms.last[:total_searches]).to eql(0)
+          expect(statistics.search_terms.last[:searches].last[:value]).to eql(0)
         end
 
         it "should replace nil values with zero for multipart links" do
-          statistics = Statistics.new(apply_uk_visa_content_multipart, '/apply-uk-visa')
-
           stub_performance_platform_has_slug_multipart('/apply-uk-visa', performance_platform_response_for_multipart_with_nil_values)
 
-          problems = statistics.problem_reports
-          page_views = statistics.page_views
-          searches = statistics.searches
+          statistics = Statistics.new(apply_uk_visa_content_multipart, '/apply-uk-visa')
+
+          expect(statistics.problem_reports.last[:value]).to eql(0)
+          expect(statistics.problem_reports.last[:path]).to eql("/apply-uk-visa/part-3")
+
+          expect(statistics.page_views.last[:value]).to eql(0)
+          expect(statistics.page_views.last[:path]).to eql("/apply-uk-visa/part-3")
+
+          expect(statistics.searches.last[:value]).to eql(0)
+          expect(statistics.searches.last[:path]).to eql("/apply-uk-visa/part-3")
+
           # there is no multipart version of search-terms
-
-          expect(problems.last[:value]).to eql(0)
-          expect(problems.last[:path]).to eql("/apply-uk-visa/part-3")
-
-          expect(page_views.last[:value]).to eql(0)
-          expect(page_views.last[:path]).to eql("/apply-uk-visa/part-3")
-
-          expect(searches.last[:value]).to eql(0)
-          expect(searches.last[:path]).to eql("/apply-uk-visa/part-3")
         end
       end
     end

--- a/spec/views/info/_lead_metrics.html.erb_spec.rb
+++ b/spec/views/info/_lead_metrics.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "info/lead_metrics" do
     top_10_search_terms: []
     }
   }
-  let(:locals) { { lead_metrics: OpenStruct.new(defaults.merge(data)), is_multipart: false } }
+  let(:locals) { { lead_metrics: OpenStruct.new(defaults.merge(data)), multipart: false } }
 
   context "when there's very little traffic" do
     let(:data) { { unique_pageviews_average: 0.5 } }
@@ -56,7 +56,7 @@ RSpec.describe "info/lead_metrics" do
     let(:data) { { unique_pageviews_average: 13245, exits_via_search_average: 12, problem_reports_weekly_average: 33 } }
 
     it "uses multipart metrics" do
-      locals[:@is_multipart] = true
+      locals[:multipart] = true
       render partial: "info/lead_metrics", locals: locals
 
       expect(rendered).to have_text("Unique pageviews 13.2k per day")


### PR DESCRIPTION
For: [Trelllo card](https://trello.com/c/oVwtZ40Z/197-improve-use-of-statistics-in-info-frontend)

Following the [removal of metadata-api](https://github.com/alphagov/info-frontend/pull/71), the `info-frontend` code introduced to replace it can stand to get some improvements to reduce indirection and remove redundancy. 

This will make the code more readable and will help us when we attempt to speed up the 4 api requests being done to the performance platform (which was previously handled by `metadata-api`).
