### PR TITLE
Add SRI attributes

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title><%= yield :title %> - GOV.UK</title>
-  <%= stylesheet_link_tag 'application', media: 'all' %>
+  <%= stylesheet_link_tag 'application', media: 'all', integrity: true, crossorigin: 'anonymous' %>
   <%= csrf_meta_tags %>
 </head>
 <body>


### PR DESCRIPTION
For: https://trello.com/c/nVb1OsNd/144-enable-subresource-integrity-sri-on-info-frontend-s

There's only one stylesheet to add them to, all other assets come from static, which we've not added SRI to yet.