### PR TITLE
Add BOM remover gem to fix SRI issues on firefox

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'slimmer', '~> 9.0'
 gem 'plek', '1.11.0'
 gem 'govuk_frontend_toolkit', '1.6.1'
 gem 'gds-api-adapters', '47.1.1'
+gem 'asset_bom_removal-rails', '~> 1.0.0'
 
 group :development, :test do
   gem 'rspec-rails', '3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,9 @@ GEM
       builder
       multi_json
     arel (7.1.1)
+    asset_bom_removal-rails (1.0.2)
+      rails (>= 4.2)
+      sass (> 3.4)
     ast (2.3.0)
     builder (3.2.2)
     capybara (2.4.1)
@@ -243,6 +246,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (= 4.0.0)
+  asset_bom_removal-rails (~> 1.0.0)
   capybara (= 2.4.1)
   ci_reporter_rspec
   gds-api-adapters (= 47.1.1)
@@ -262,4 +266,4 @@ DEPENDENCIES
   webmock (~> 2.3.2)
 
 BUNDLED WITH
-   1.14.5
+   1.15.1


### PR DESCRIPTION
For: https://trello.com/c/nVb1OsNd/144-enable-subresource-integrity-sri-on-info-frontend-s

This injects itself into the rails asset pipeline and makes sure that
the CSS we compress with sass does not include a BOM if it is a UTF-8
file.  Firefox < 52 has a bug in how it calculates SRI hashes for CSS
files with a BOM and this gem mitigates that.  Currently none of the
delivered CSS assets are UTF-8, so it wouldn't be a huge problem if
we didn't use this, but it hasn't always been the case and we don't
want the addition of one character in a CSS file to break things in
the future for some users.

Should have added this to #76 but I forgot 😞 