### PR TITLE
Remove code related to need_ids

### DIFF
--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -34,7 +34,6 @@ feature "Info page" do
       updated_at
       first_published_at
       publishing_app
-      need_ids
       format
       phase
       publishing_request_id

--- a/spec/models/performance_data/statistics_spec.rb
+++ b/spec/models/performance_data/statistics_spec.rb
@@ -123,7 +123,6 @@ module PerformanceData
         updated_at
         first_published_at
         publishing_app
-        need_ids
         format
         phase
         publishing_request_id


### PR DESCRIPTION
This field has now been replaced by the `meets_user_needs` link type.