### PR TITLE
Remove shonky error handling

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -11,16 +11,9 @@ class InfoController < ApplicationController
 
   def show
     @slug = parse_slug
-
     @content = content_store.content_item(@slug).to_h
     @needs = @content["links"]["meets_user_needs"]
-
-    begin
-      @statistics = PerformanceData::Statistics.new(@content, @slug)
-    rescue StandardError => e
-      logger.error "Performance data related error for #{@slug}"
-      logger.error e.message
-    end
+    @statistics = PerformanceData::Statistics.new(@content, @slug)
   end
 
 private
@@ -35,5 +28,3 @@ private
     head 404
   end
 end
-
-

--- a/app/views/info/show.html.erb
+++ b/app/views/info/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title do "Information about “#{@content["title"]}”" end %>
 
 <%= render partial: "content", locals: { content: @content } %>
+
 <%= render partial: "lead_metrics", locals: { lead_metrics: @statistics.lead_metrics, multipart: @statistics.multipart? } %>
 <%= render partial: "per_page_metrics", locals: { per_page_metrics: @statistics.per_page_metrics } %>
 <%= render partial: "needs", locals: { needs: @needs, multipart: @statistics.multipart? } %>


### PR DESCRIPTION
This `rescue` causes `@statistics` to be nil and the view to crash eventually, but without an informative message in Sentry. This will at least give us the actual error in Sentry.