### PR TITLE
Use gem based components

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 class ApplicationController < ActionController::Base
-  include Slimmer::GovukComponents
-
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/views/info/_content.html.erb
+++ b/app/views/info/_content.html.erb
@@ -1,8 +1,8 @@
 <div class="need-heading">
-  <%= render partial: 'govuk_component/title', locals: {
+  <%= render 'govuk_publishing_components/components/title',
   context: "User needs and metrics",
   title: content["title"]
-  } %>
+  %>
   <p class="introduction">
     All metrics are recorded over the past 6 weeks.
   </p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
 <body>
   <div id="global-breadcrumb" class="header-context"></div>
   <div id="wrapper">
-    <%= render 'govuk_component/alpha_label' %>
+    <%= render 'govuk_publishing_components/components/phase_banner', phase: 'alpha' %>
     <main role="main" class="info-frontend">
       <%= yield %>
     </main>

--- a/spec/support/slimmer.rb
+++ b/spec/support/slimmer.rb
@@ -1,9 +1,1 @@
 require 'slimmer/test'
-require 'slimmer/test_helpers/govuk_components'
-
-RSpec.configure do |c|
-  c.include Slimmer::TestHelpers::GovukComponents, type: :feature
-  c.before(:each, type: :feature) do
-    stub_shared_component_locales
-  end
-end


### PR DESCRIPTION
This uses the title and phase banner component from the gem rather than static. Because we're no longer using Static-based components this also removes the Slimmer helpers.

https://trello.com/c/qtXCDGQI