### PR TITLE
Add all JavaScript dependencies from govuk_publishing_components

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,1 +1,1 @@
-//= require govuk_publishing_components/components/feedback
+//= require govuk_publishing_components/all_components


### PR DESCRIPTION
This is one of the few remaining apps that don't require all scripts form govuk_publishing_components.