### PR TITLE
Exclude `links` from payload in schema tests

### DIFF
--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -38,6 +38,7 @@ feature "Info page" do
       format
       phase
       publishing_request_id
+      links
     ) + supertype_fields
 
     @apply_uk_visa_content = GovukSchemas::RandomExample.for_schema(

--- a/spec/models/performance_data/statistics_spec.rb
+++ b/spec/models/performance_data/statistics_spec.rb
@@ -129,6 +129,7 @@ module PerformanceData
         navigation_document_supertype
         government_document_supertype
         email_document_supertype
+        links
       ) + supertype_fields
       need.except(*fields_to_exclude)
     end


### PR DESCRIPTION
Trello: https://trello.com/c/uR7v1Rri

The changes introduced in https://github.com/alphagov/govuk-content-schemas/pull/891
are causing the info-frontend schema tests to fail.

These changes remove the `links` hash from the random examples completely and allow them to be
overwritten in the tests.

See:
https://ci.integration.publishing.service.gov.uk/job/info-frontend/job/deployed-to-production/119/