### PR TITLE
Revert "Bump govuk_publishing_components from 17.21.0 to 19.0.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "govuk_app_config", "~> 2.0.0"
 gem 'govuk_frontend_toolkit', '8.2.0'
 gem 'gds-api-adapters'
 gem 'asset_bom_removal-rails', '~> 1.0.0'
-gem 'govuk_publishing_components', '~> 19.0.0'
+gem 'govuk_publishing_components', '~> 17.21.0'
 
 group :development, :test do
   gem 'rspec-rails', '3.8.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (19.0.0)
+    govuk_publishing_components (17.21.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -144,7 +144,7 @@ GEM
     minitest (5.11.3)
     multipart-post (2.1.1)
     netrc (0.11.0)
-    nio4r (2.5.1)
+    nio4r (2.4.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     null_logger (0.0.1)
@@ -174,7 +174,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.2.0)
+    rails-html-sanitizer (1.1.0)
       loofah (~> 2.2, >= 2.2.2)
     railties (5.2.3)
       actionpack (= 5.2.3)
@@ -196,7 +196,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.9.0)
+    rouge (3.7.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -246,8 +246,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.2.0)
+    sassc (2.0.1)
       ffi (~> 1.9)
+      rake
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -311,7 +312,7 @@ DEPENDENCIES
   govuk-lint
   govuk_app_config (~> 2.0.0)
   govuk_frontend_toolkit (= 8.2.0)
-  govuk_publishing_components (~> 19.0.0)
+  govuk_publishing_components (~> 17.21.0)
   govuk_schemas (~> 4)
   plek (= 3.0.0)
   rails (~> 5.2)


### PR DESCRIPTION
Reverts alphagov/info-frontend#534

Version 18 and 19 of the govuk_publishing_components are breaking versions, as they introduce GOVUK Frontend Version 3 which in itself is a breaking change. We need to address some styling and mixin issues introduced as a result of this change before we can merge in version 19 of the gem.

Example issue:
<img width="1023" alt="Screen Shot 2019-09-04 at 09 51 29" src="https://user-images.githubusercontent.com/29889908/64240398-b4fa6c80-cef9-11e9-877e-46081f251588.png">
Smaller font size on certain parts of the page.