### PR TITLE
Replace govuk-lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,6 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 AllCops:
   TargetRubyVersion: 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem "uglifier", "4.2.0"
 
 group :development, :test do
   gem "ci_reporter_rspec"
-  gem "govuk-lint"
   gem "rspec-rails", "3.9.0"
+  gem "rubocop-govuk"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,11 +84,6 @@ GEM
       rest-client (~> 2.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-lint (4.2.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.12.0)
@@ -225,6 +220,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -251,8 +250,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     sentry-raven (2.11.3)
       faraday (>= 0.7.6, < 1.0)
     slimmer (13.2.0)
@@ -304,7 +301,6 @@ DEPENDENCIES
   capybara (= 3.29.0)
   ci_reporter_rspec
   gds-api-adapters
-  govuk-lint
   govuk_app_config (~> 2.0.1)
   govuk_publishing_components (~> 21.10.0)
   govuk_schemas (~> 4)
@@ -312,6 +308,7 @@ DEPENDENCIES
   rails (~> 5.2)
   rspec-its (= 1.3.0)
   rspec-rails (= 3.9.0)
+  rubocop-govuk
   sass-rails (~> 5.0.5)
   slimmer (~> 13.2.0)
   spring


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk