### PR TITLE
Remove crossorigin and SRI from our static assets (CSS/JS)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title><%= yield :title %> - GOV.UK</title>
-  <%= stylesheet_link_tag 'application', media: 'all', integrity: true, crossorigin: 'anonymous' %>
-  <%= javascript_include_tag 'application', integrity: true, crossorigin: 'anonymous' %>
+  <%= stylesheet_link_tag 'application', media: 'all', integrity: false %>
+  <%= javascript_include_tag 'application', integrity: false %>
   <%= csrf_meta_tags %>
 </head>
 <body>


### PR DESCRIPTION
Change to remove SRI on the JavaScript / CSS and remove the `crossorigin` attribute.

This change is part of [RFC-115](https://github.com/alphagov/govuk-rfcs/pull/115).

Changes have been tested on integration, [seen here](https://github.com/alphagov/static/pull/1993#issuecomment-580287175)