### PR TITLE
Fix deprecation messages for content_store stubs

### DIFF
--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -92,7 +92,7 @@ feature "Info page" do
 
   scenario "Understanding the needs of a page" do
     stub_performance_platform_has_slug("/apply-uk-visa", performance_platform_response_for_apply_uk_visa)
-    content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
+    stub_content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
 
     visit "/info/apply-uk-visa"
 
@@ -116,7 +116,7 @@ feature "Info page" do
 
   scenario "Seeing how many visits are made to a page" do
     stub_performance_platform_has_slug("/apply-uk-visa", performance_platform_response_for_apply_uk_visa)
-    content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
+    stub_content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
 
     visit "/info/apply-uk-visa"
 
@@ -125,7 +125,7 @@ feature "Info page" do
 
   scenario "Seeing metrics for multi-part formats" do
     stub_performance_platform_has_slug_multipart("/apply-uk-visa", performance_platform_response_for_multipart_artefact)
-    content_store_has_item("/apply-uk-visa", @apply_uk_visa_content_multipart)
+    stub_content_store_has_item("/apply-uk-visa", @apply_uk_visa_content_multipart)
 
     visit "/info/apply-uk-visa"
 
@@ -171,7 +171,7 @@ feature "Info page" do
 
   scenario "Seeing how many users are leaving via the site search" do
     stub_performance_platform_has_slug("/apply-uk-visa", performance_platform_response_for_apply_uk_visa)
-    content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
+    stub_content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
 
     visit "/info/apply-uk-visa"
 
@@ -180,7 +180,7 @@ feature "Info page" do
 
   scenario "Seeing how problem reports are left" do
     stub_performance_platform_has_slug("/apply-uk-visa", performance_platform_response_for_apply_uk_visa)
-    content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
+    stub_content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
 
     visit "/info/apply-uk-visa"
 
@@ -189,7 +189,7 @@ feature "Info page" do
 
   scenario "Seeing what terms users are searching for" do
     stub_performance_platform_has_slug("/apply-uk-visa", performance_platform_response_for_apply_uk_visa)
-    content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
+    stub_content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
 
     visit "/info/apply-uk-visa"
 
@@ -199,7 +199,7 @@ feature "Info page" do
 
   scenario "Seeing where there aren’t any recorded user needs" do
     stub_performance_platform_has_slug("/some-slug", performance_platform_response_for_apply_uk_visa)
-    content_store_has_item("/some-slug", @apply_uk_visa_content_with_no_needs)
+    stub_content_store_has_item("/some-slug", @apply_uk_visa_content_with_no_needs)
 
     visit "/info/some-slug"
 
@@ -208,7 +208,7 @@ feature "Info page" do
 
   scenario "When there isn't any performance data available" do
     stub_performance_platform_has_slug("/some-slug", performance_platform_response_with_no_performance_data)
-    content_store_has_item("/some-slug", @apply_uk_visa_content)
+    stub_content_store_has_item("/some-slug", @apply_uk_visa_content)
 
     visit "/info/some-slug"
 
@@ -218,7 +218,7 @@ feature "Info page" do
 
   scenario "When no information is available for a given slug" do
     stub_performance_platform_has_no_data_for_slug("/slug-without-info")
-    content_store_does_not_have_item("/slug-without-info")
+    stub_content_store_does_not_have_item("/slug-without-info")
 
     visit "/info/slug-without-info"
 
@@ -227,7 +227,7 @@ feature "Info page" do
 
   scenario "when a slug that needs encoding is provided" do
     stub_performance_platform_has_slug("/government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8", performance_platform_response_for_apply_uk_visa)
-    content_store_has_item("/government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8", @apply_uk_visa_content)
+    stub_content_store_has_item("/government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8", @apply_uk_visa_content)
 
     visit "/info/government/publications/apply-for-a-uk-visa-in-china/%E5%9C%A8"
 
@@ -236,7 +236,7 @@ feature "Info page" do
 
   scenario "shows the user need when it's valid" do
     stub_performance_platform_has_slug("/apply-uk-visa", performance_platform_response_for_apply_uk_visa)
-    content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
+    stub_content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
 
     visit "/info/apply-uk-visa"
 


### PR DESCRIPTION
Replace instances of content_store_has_item with stub_content_store_has_item in the tests in line with the deprecation message: `content_store_has_item is deprecated on GdsApi::TestHelpers::ContentStore and will be removed in a future version. Use #stub_content_store_has_item instead`