### PR TITLE
Remove ActiveRecord setup in production config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,5 +95,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-  ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  # ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 end


### PR DESCRIPTION
During the rails migration this line was added to the production config: `ActiveRecord::Middleware::DatabaseSelector::Resolver::Session`, this causes the deploy to fail since the application does not use its own database. Here we have commented it out again (as it was generated in the rails 6 upgrade).

Trello ticket: https://trello.com/c/0d6k3UdH/1798-5-upgrade-info-frontend-to-rails-6#comment-5e6794e41f9f4e5f9d34f079