### PR TITLE
Add slimmer to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
         dependency-type: direct
       - dependency-name: rubocop-govuk
         dependency-type: direct
+      - dependency-name: slimmer
+        dependency-type: direct
       # Framework gems
       - dependency-name: rails
         dependency-type: direct


### PR DESCRIPTION
This got missed in the initial config creation.
As Slimmer is an internal gem, it should be added
to the config.

https://trello.com/c/uPoriyfJ/2049-add-dependabot-configuration-to-each-repo-blitz-pair