### PR TITLE
Upgrade to Ruby 2.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-ruby File.read(".ruby-version").strip
-
 gem "rails", "6.0.3.3"
 
 gem "gds-api-adapters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
     parser (2.7.1.4)
       ast (~> 2.4.1)
     plek (4.0.0)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -226,8 +226,8 @@ GEM
       rubocop-ast (>= 0.1.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.2.0)
-      parser (>= 2.7.0.1)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
     rubocop-govuk (3.17.0)
       rubocop (= 0.87.1)
       rubocop-rails (= 2.6.0)
@@ -263,7 +263,7 @@ GEM
       plek (>= 1.1.0)
       rack
       rest-client
-    spring (2.1.0)
+    spring (2.1.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -317,9 +317,6 @@ DEPENDENCIES
   spring
   uglifier
   webmock
-
-RUBY VERSION
-   ruby 2.6.6p146
 
 BUNDLED WITH
    1.17.3

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -17,7 +17,8 @@ class InfoController < ApplicationController
 private
 
   def parse_slug
-    slug = URI.encode(params[:slug]) # rubocop:disable Lint/UriEscapeUnescape
+    query = params[:slug]
+    slug = URI.encode_www_form_component(query).gsub("%2F", "/")
     slug[0] != "/" ? "/#{slug}" : slug
   end
 


### PR DESCRIPTION
## What

Upgrade to Ruby `2.7.1` and fix the warning `URI.escape is obsolete`