### PR TITLE
Disable performance platform

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -11,7 +11,10 @@ class InfoController < ApplicationController
     @slug = parse_slug
     @content = GdsApi.content_store.content_item(@slug).to_h
     @needs = @content["links"]["meets_user_needs"]
-    @statistics = PerformanceData::Statistics.new(@content, @slug)
+
+    # TODO: performance platform no longer exists.
+    # If we want statistics, they need to come from somewhere else.
+    @statistics = nil
   end
 
 private

--- a/app/views/info/show.html.erb
+++ b/app/views/info/show.html.erb
@@ -2,6 +2,6 @@
 
 <%= render partial: "content", locals: { content: @content } %>
 
-<%= render partial: "lead_metrics", locals: { lead_metrics: @statistics.lead_metrics, multipart: @statistics.multipart? } %>
-<%= render partial: "per_page_metrics", locals: { per_page_metrics: @statistics.per_page_metrics } %>
-<%= render partial: "needs", locals: { needs: @needs, multipart: @statistics.multipart? } %>
+<%#= render partial: "lead_metrics", locals: { lead_metrics: @statistics.lead_metrics, multipart: @statistics.multipart? } %>
+<%#= render partial: "per_page_metrics", locals: { per_page_metrics: @statistics.per_page_metrics } %>
+<%= render partial: "needs", locals: { needs: @needs, multipart: false } %>

--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -112,7 +112,7 @@ feature "Info page" do
     expect(page.response_headers["Cache-Control"]).to eq("max-age=43200, public")
   end
 
-  scenario "Seeing how many visits are made to a page" do
+  xscenario "Seeing how many visits are made to a page" do
     stub_performance_platform_has_slug("/apply-uk-visa", performance_platform_response_for_apply_uk_visa)
     stub_content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
 
@@ -121,7 +121,7 @@ feature "Info page" do
     expect(page).to have_text("Unique pageviews\n25.9k per day")
   end
 
-  scenario "Seeing metrics for multi-part formats" do
+  xscenario "Seeing metrics for multi-part formats" do
     stub_performance_platform_has_slug_multipart("/apply-uk-visa", performance_platform_response_for_multipart_artefact)
     stub_content_store_has_item("/apply-uk-visa", @apply_uk_visa_content_multipart)
 
@@ -171,7 +171,7 @@ feature "Info page" do
     end
   end
 
-  scenario "Seeing how many users are leaving via the site search" do
+  xscenario "Seeing how many users are leaving via the site search" do
     stub_performance_platform_has_slug("/apply-uk-visa", performance_platform_response_for_apply_uk_visa)
     stub_content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
 
@@ -180,7 +180,7 @@ feature "Info page" do
     expect(page).to have_text("Searches started from this page\n72 per day")
   end
 
-  scenario "Seeing how problem reports are left" do
+  xscenario "Seeing how problem reports are left" do
     stub_performance_platform_has_slug("/apply-uk-visa", performance_platform_response_for_apply_uk_visa)
     stub_content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
 
@@ -189,7 +189,7 @@ feature "Info page" do
     expect(page).to have_text("Problem reports\n140 per week")
   end
 
-  scenario "Seeing what terms users are searching for" do
+  xscenario "Seeing what terms users are searching for" do
     stub_performance_platform_has_slug("/apply-uk-visa", performance_platform_response_for_apply_uk_visa)
     stub_content_store_has_item("/apply-uk-visa", @apply_uk_visa_content)
 
@@ -208,7 +208,7 @@ feature "Info page" do
     expect(page).to have_text("There aren’t any validated needs for this page.")
   end
 
-  scenario "When there isn't any performance data available" do
+  xscenario "When there isn't any performance data available" do
     stub_performance_platform_has_slug("/some-slug", performance_platform_response_with_no_performance_data)
     stub_content_store_has_item("/some-slug", @apply_uk_visa_content)
 


### PR DESCRIPTION
The performance platform API has been decommissioned.

None of the statistics that used to come from performance platform will work anymore.

User needs from Maslow are still okay though :tada: 

![image](https://user-images.githubusercontent.com/1696784/111172545-d1bb3a00-859d-11eb-9276-580c60262dd1.png)


For now, I'm just commenting out the places where we called the performance platform's API.

If we want this functionality back we could look at pulling it directly from Google Analytics, or from Search or from Content Data.

https://trello.com/c/DVnwOgMg/2090-performance-platform-retirement-handle-info-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
