### PR TITLE
Fix publish special routes rake task

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -6,7 +6,7 @@ namespace :publishing_api do
   desc "Publish special routes via publishing api"
   task publish_special_routes: :environment do
     logger = Logger.new(STDOUT)
-    publishing_api = GdsApi::PublishingApiV2.new(
+    publishing_api = GdsApi::PublishingApi.new(
       Plek.new.find("publishing-api"),
       bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
     )

--- a/spec/lib/tasks/publishing_api_spec.rb
+++ b/spec/lib/tasks/publishing_api_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+require "gds_api/test_helpers/publishing_api"
+require "rake"
+
+RSpec.describe "publishing_api.rake" do
+  include GdsApi::TestHelpers::PublishingApi
+
+  it "should publish special routes" do
+    content_id = "bce40c1f-2259-4404-b275-8c5e04afef34"
+
+    put_content_stub = stub_publishing_api_put_content(content_id, {})
+    publish_content_stub = stub_publishing_api_publish(content_id, {})
+
+    Rake.application["publishing_api:publish_special_routes"].invoke
+
+    expect(put_content_stub).to have_been_requested.once
+    expect(publish_content_stub).to have_been_requested.once
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,4 +10,6 @@ require "rspec/rails"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
+Rails.application.load_tasks
+
 RSpec.configure(&:infer_spec_type_from_file_location!)


### PR DESCRIPTION
Replace defunct use of PublishingApiV2 in rake task

GdsApi no longer exports PublishingApiV2, so this rake task has been broken for a while. No biggy because it never had any tests, and we don't run it regularly. Still probably worth fixing (or removing?).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
