### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,6 @@ Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide"
   get "info/:slug" => "info#show", constraints: { slug: /.*/ }
 
-  get "/healthcheck", to: GovukHealthcheck.rack_response
-
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response
 end


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
