### PR TITLE
Swap to `gem_layout` and adopt new link styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 $govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
+$govuk-new-link-styles: true;
 
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/components/button';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,7 @@
-$govuk-compatibility-govuktemplate: true;
+$govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
+
 @import 'govuk_publishing_components/govuk_frontend_support';
-@import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/feedback';

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include Slimmer::Template
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
@@ -9,6 +10,8 @@ class ApplicationController < ActionController::Base
       password: ENV.fetch("BASIC_AUTH_PASSWORD"),
     )
   end
+
+  slimmer_template :gem_layout
 
 private
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,6 @@
     <main role="main" class="info-frontend">
       <%= yield %>
     </main>
-    <%= render 'govuk_publishing_components/components/feedback' %>
   </div>
 </body>
 </html>


### PR DESCRIPTION
### What

Update `info-frontend` to use the Design System-based page layout and turn on the `govuk-new-link-styles` flag.

### Why

Major benefits include performance improvements, accessibility improvements, and consistency with other applications.

### Visual changes
No visual changes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
