### PR TITLE
Respect Content Store TTL

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,12 +12,4 @@ class ApplicationController < ActionController::Base
   end
 
   slimmer_template :gem_layout
-
-private
-
-  def set_expiry(duration = 12.hours)
-    unless Rails.env.development?
-      expires_in(duration, public: true)
-    end
-  end
 end

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -3,15 +3,23 @@ require "uri"
 class InfoController < ApplicationController
   rescue_from GdsApi::ContentStore::ItemNotFound, with: :not_found
   rescue_from GdsApi::HTTPGone, with: :not_found
-  before_action :set_expiry, only: :show
 
   def show
     @slug = parse_slug
-    @content = GdsApi.content_store.content_item(@slug).to_h
+    @content_item = GdsApi.content_store.content_item(@slug)
+    set_expiry
+    @content = @content_item.to_h
     @needs = @content["links"]["meets_user_needs"]
   end
 
 private
+
+  def set_expiry
+    expires_in(
+      @content_item.cache_control.max_age,
+      public: !@content_item.cache_control.private?,
+    )
+  end
 
   def parse_slug
     query = params[:slug]

--- a/spec/features/info_spec.rb
+++ b/spec/features/info_spec.rb
@@ -106,7 +106,7 @@ feature "Info page" do
     expect(page).to have_text("How to apply")
     expect(page).to have_text("What documents to provide")
 
-    expect(page.response_headers["Cache-Control"]).to eq("max-age=43200, public")
+    expect(page.response_headers["Cache-Control"]).to eq("max-age=900, public")
   end
 
   scenario "Seeing where there aren’t any recorded user needs" do


### PR DESCRIPTION
Content Store provides a TTL in the Cache-Control response header which frontend apps should respect.

This ensures that Info-frontend honours the cache TTL provided by Content Store.

This partially implements RFC 144.

Links:
* Content Store TTL: https://github.com/alphagov/content-store/blob/9661e2047f2167f87066fbb6ef38da71668a1327/app/controllers/content_items_controller.rb#L14
* RFC 144: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-144-consistent-cache-expiry.md

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


https://trello.com/c/OaUhq6uI/722-replatform-emergency-banner