### PR TITLE
Adding Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+
+# TODO: make this default to govuk-ruby once it's being pushed somewhere public
+# (unless we decide to use Bitnami instead)
+ARG base_image=ruby:2.7.2
+
+FROM $base_image AS builder
+# This image is only intended to be able to run this app in a production RAILS_ENV
+ENV RAILS_ENV=production
+# TODO: have a separate build image which already contains the build-only deps.
+RUN apt-get update -qy && \
+    apt-get upgrade -y && \
+    apt-get install -y build-essential nodejs && \
+    apt-get clean
+
+RUN mkdir /app
+WORKDIR /app
+COPY Gemfile Gemfile.lock .ruby-version /app/
+RUN bundle config set deployment 'true' && \
+    bundle config set without 'development test' && \
+    bundle install --jobs 4 --retry=2
+COPY . /app
+
+RUN GOVUK_APP_DOMAIN=www.gov.uk \
+    GOVUK_WEBSITE_ROOT=http://www.gov.uk \
+    bundle exec rails assets:precompile
+# QQ:  rake shared_mustache:compile is this app specific?
+
+FROM $base_image
+ENV RAILS_ENV=production GOVUK_APP_NAME=info-frontend
+
+# bundler seems to need nodejs installed - or at least a JavaScript runtime
+RUN apt-get update -qy && \
+    apt-get upgrade -y && \
+    apt-get install -y nodejs && \
+    apt-get clean
+
+WORKDIR /app
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+COPY --from=builder /app ./
+CMD bundle exec puma

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-
 # TODO: make this default to govuk-ruby once it's being pushed somewhere public
 # (unless we decide to use Bitnami instead)
 ARG base_image=ruby:2.7.2
@@ -11,7 +10,6 @@ RUN apt-get update -qy && \
     apt-get upgrade -y && \
     apt-get install -y build-essential nodejs && \
     apt-get clean
-
 RUN mkdir /app
 WORKDIR /app
 COPY Gemfile Gemfile.lock .ruby-version /app/
@@ -19,21 +17,18 @@ RUN bundle config set deployment 'true' && \
     bundle config set without 'development test' && \
     bundle install --jobs 4 --retry=2
 COPY . /app
-
+# TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
 RUN GOVUK_APP_DOMAIN=www.gov.uk \
-    GOVUK_WEBSITE_ROOT=http://www.gov.uk \
+    GOVUK_WEBSITE_ROOT=https://www.gov.uk \
     bundle exec rails assets:precompile
-# QQ:  rake shared_mustache:compile is this app specific?
 
 FROM $base_image
 ENV RAILS_ENV=production GOVUK_APP_NAME=info-frontend
-
 # bundler seems to need nodejs installed - or at least a JavaScript runtime
 RUN apt-get update -qy && \
     apt-get upgrade -y && \
     apt-get install -y nodejs && \
     apt-get clean
-
 WORKDIR /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app ./

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_puma"
+GovukPuma.configure_rails(self)


### PR DESCRIPTION
Adding a Dockerfile so that info-frontend can be migrated to the EKS platform. 
Adding a puma config file so that puma is used as the web server.
