### PR TITLE
Adding soft link to /tmp filesystem.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,18 @@ ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=info-fron
 RUN apt-get update -qy && \
     apt-get upgrade -y && \
     apt-get install -y nodejs && \
-    apt-get clean
-WORKDIR /app
+    apt-get clean 
+
+RUN mkdir /app && ln -fs /tmp /app
+
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app ./
+
+WORKDIR /app
+
+RUN groupadd -g 1001 app && \
+    useradd app -u 1001 -g 1001 --home /app
+
+USER app
+
 CMD bundle exec puma


### PR DESCRIPTION
This should allow writing to /app/tmp directory and fix the current permission denied errors in EKS.

This is part of non-root container work:
https://trello.com/c/Jef1t4xU/903-fix-app-permission-errors-due-to-nonroot

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
