### PR TITLE
Tidy up stylesheets and JavaScript

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,2 @@
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/button
-//= require govuk_publishing_components/components/feedback

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,15 +3,8 @@ $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 
 @import 'govuk_publishing_components/govuk_frontend_support';
-@import 'govuk_publishing_components/components/button';
-@import 'govuk_publishing_components/components/error-message';
-@import 'govuk_publishing_components/components/feedback';
-@import 'govuk_publishing_components/components/hint';
-@import 'govuk_publishing_components/components/input';
-@import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/phase-banner';
 @import 'govuk_publishing_components/components/table';
-@import 'govuk_publishing_components/components/title';
 
 .info-frontend {
   @include govuk-clearfix;

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,3 +1,2 @@
 @import 'govuk_publishing_components/govuk_frontend_support';
-@import 'govuk_publishing_components/components/print/button';
 @import 'govuk_publishing_components/components/print/title';


### PR DESCRIPTION
## What

Remove stylesheets and JavaScript that's:

 - already included in `static`'s stylesheets or JavaScript
 - for components that this application isn't currently using

## Why

Static serves a stylesheet and a JavaScript file on every page across GOV.UK - so if code is shared by multiple applications, this is the place for it to go. This ensures that the file is cached across a user's entire journey - rather than just the pages rendered by a single application.

## Visual changes

None.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
