### PR TITLE
Switch asset host env var for change of asset host

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,13 @@ module InfoFrontend
     # to use CSS that has same function names as SCSS such as max.
     config.assets.css_compressor = nil
 
+    # Path within public/ where assets are compiled to
+    config.assets.prefix = "/assets/info-frontend"
+
+    # Allow overriding the asset host with an enironment variable, useful for
+    # when router is proxying to this app but asset proxying isn't set up.
+    config.asset_host = ENV["ASSET_HOST"]
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
This allows asset host to be set by ASSET_HOST env var as it looks like the assets of this app changed hostname from
assets.publishing.service.gov.uk to www.gov.uk as outlined in [RFC 115][rfc-115].

[rfc-115]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-115-enabling-http2-on-govuk.md

As part of this change the path to assets is changed to `/assets/info-frontend`

This should fix the JS errors in staging flagged by [Smokey](https://deploy.blue.staging.govuk.digital/job/Smokey/19922/console) during deploy (tested by deploying a branch to staging).

<kbd><img width="790" alt="Screenshot 2022-07-13 at 16 30 28" src="https://user-images.githubusercontent.com/38078064/178772928-69839064-4970-45db-af86-2f197eb2927d.png"></kbd>



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
