### PR TITLE
Turn off font

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,11 @@ $govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 
+// This flag stops the font from being included in this application's
+// stylesheet - the font is being served by Static across all of GOV.UK, so is
+// not needed here.
+$govuk-include-default-font-face: false;
+
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/components/phase-banner';
 


### PR DESCRIPTION
## What

Prevent the font from being included in `info-frontend`'s stylesheet.

## Why

We should be serving the font files from `static` so they're cached across the entirety of GOVUK - so the font shouldn't be included in `info-frontend`'s stylesheet.

With the font being served by each application, users need to re-download it every time they went from a page rendered in one application to a page rendered in another application.

Serving it from `static` means that the same font URI is used in each application, allowing the fonts to be cached and reused.

## Visual changes

None - the same font is being served from `static`, instead of `info-frontend`.

Before (the font paths contains `info-frontend`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181274529-b62f4bde-87de-443b-a216-7742b2caedc2.png">

After (the font path contains `static`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181274491-7d6eb883-4fb8-4f61-a0e3-a8f06a915ed9.png">

---

## Search page examples to sanity check:

- https://govuk-info-frontend-pr-1077.herokuapp.com/info/guidance/move-to-the-uk-if-youre-from-ukraine