### PR TITLE
Fix environment variable name for Search API backend.

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
     "PLEK_SERVICE_CONTENT_STORE_URI": {
       "value": "https://www.gov.uk/api"
     },
-    "PLEK_SERVICE_SEARCH_URI": {
+    "PLEK_SERVICE_SEARCH_API_URI": {
       "value": "https://www.gov.uk/api"
     },
     "PLEK_SERVICE_STATIC_URI": {


### PR DESCRIPTION
See alphagov/gds-api-adapters#1170.