### PR TITLE
Remove Rails 7 cookie rotation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,22 +42,5 @@ module InfoFrontend
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
-
-    # Rotate SHA1 cookies to SHA256 (the new Rails 7 default)
-    # TODO: Remove this after existing user sessions have been rotated
-    # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256
-    Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
-      salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
-      secret_key_base = Rails.application.secrets.secret_key_base
-      next if secret_key_base.blank?
-
-      key_generator = ActiveSupport::KeyGenerator.new(
-        secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
-      )
-      key_len = ActiveSupport::MessageEncryptor.key_len
-      secret = key_generator.generate_key(salt, key_len)
-
-      cookies.rotate :encrypted, secret
-    end
   end
 end


### PR DESCRIPTION
This has not been needed since this app was deployed (if at all, as I don't think this app uses sessions).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
