### PR TITLE
Make ruby tests a reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,26 +21,5 @@ jobs:
 
   test-ruby:
     name: Test Ruby
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Checkout Publishing API (for Content Schemas)
-        uses: actions/checkout@v3
-        with:
-          repository: alphagov/publishing-api
-          ref: deployed-to-production
-          path: vendor/publishing-api
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - name: Run RSpec
-        env:
-          RAILS_ENV: test
-          GOVUK_CONTENT_SCHEMAS_PATH: vendor/publishing-api/content_schemas
-        run: bundle exec rake spec
+    uses: ./.github/workflows/rspec.yml
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,46 @@
+name: Run RSpec
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'The branch, tag or SHA to checkout'
+        required: false
+        type: string
+      publishingApiRef:
+        description: 'The branch, tag or SHA to checkout Publishing API'
+        required: false
+        default: 'deployed-to-production'
+        type: string
+
+jobs:
+  run-rspec:
+    name: Run RSpec
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: alphagov/info-frontend
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Checkout Publishing API (for Content Schemas)
+        uses: actions/checkout@v3
+        with:
+          repository: alphagov/publishing-api
+          ref: ${{ inputs.publishingApiRef }}
+          path: vendor/publishing-api
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Precompile assets
+        uses: alphagov/govuk-infrastructure/.github/actions/precompile-rails-assets@main
+
+      - name: Run RSpec
+        env:
+          RAILS_ENV: test
+          GOVUK_CONTENT_SCHEMAS_PATH: vendor/publishing-api/content_schemas
+        run: bundle exec rake spec


### PR DESCRIPTION
This application depends on the Content Schemas. Making the tests
reusable allows Publishing API to run the tests when the Content Schemas
are updated.
