### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem "bootsnap", require: false
 gem "gds-api-adapters"
 gem "govuk_app_config"
 gem "govuk_publishing_components"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "plek"
 gem "sass-rails"
 gem "slimmer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,7 +359,6 @@ DEPENDENCIES
   govuk_app_config
   govuk_publishing_components
   govuk_schemas
-  mail (~> 2.8.0)
   plek
   rails (= 7.0.4)
   rspec-its


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the `mail` gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to `2.8.0.1`, which fixes the permissions issue.

Generated with `gsed -i '/gem "mail"/d' && bundle update mail`.
