### PR TITLE
Remove unneeded instances of ga4_tracking: true

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
 <body>
   <div id="global-breadcrumb" class="header-context"></div>
   <div id="wrapper">
-    <%= render 'govuk_publishing_components/components/phase_banner', phase: 'alpha', ga4_tracking: true %>
+    <%= render 'govuk_publishing_components/components/phase_banner', phase: 'alpha' %>
     <main role="main" class="info-frontend">
       <%= yield %>
     </main>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove options passed to components for enabling GA4 tracking. All components referenced now have tracking enabled by default, and this option has been removed.

## Why
Unneeded code.

## Visual changes
None.

Trello card: https://trello.com/c/Xwp7dgJN/294-tracking-auditing-tracking-by-default
